### PR TITLE
IVS Documentation update

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -18,7 +18,7 @@ Smartcomply's developer documentation is concise and tailored to get you up and 
 <p>Smartcomply offers modern financial infrastructure for internet companies and developers across Africa, enabling access to financial data, issuing virtual bank accounts and payment debit cards, and collecting payments directly from bank accounts.
 Our API offers robust capabilities to calculate and generate fraud probabilities for transactions and also monitor and report transactions, empowering you to detect and mitigate fraudulent activities effectively.</p>
 <p>The Smartcomply API provides an interactive and easy-to-use structure that helps developers get started conveniently.
-Smartcomply is currently available in Nigeria, Ghana, Kenya, Rwanda, and Uganda. However, the team is working to expand its services to other countries.</p>
+Smartcomply is currently available in Nigeria, Ghana, and Kenya, Rwanda. However, the team is working to expand its services to other countries.</p>
 
 <h3>Smartcomply Products:</h3>
 

--- a/mint.json
+++ b/mint.json
@@ -107,15 +107,8 @@
                 "kyc/ghana/meter_payment_history",
                 "kyc/ghana/ID_Card"
               ]
-            },
-            {
-              "group": "Rwanda",
-              "pages": ["kyc/rwanda/national_id", "kyc/rwanda/passport"]
-            },
-            {
-              "group": "Uganda",
-              "pages": ["kyc/uganda/national_id"]
             }
+           
           ]
         },
         {

--- a/mint.json
+++ b/mint.json
@@ -59,8 +59,6 @@
                 "kyc/nigeria/Drivers_License",
                 "kyc/nigeria/passport_verification",
                 "kyc/nigeria/nuban",
-                "kyc/nigeria/digital_address_verification",
-                "kyc/nigeria/Digital_Address_Verification_Confirmation",
                 "kyc/nigeria/phone_number_basic",
                 "kyc/nigeria/Phone_Number_Advanced",
                 "kyc/nigeria/CAC",
@@ -72,10 +70,8 @@
                 "kyc/nigeria/BVN_Advanced",
                 "kyc/nigeria/tin",
                 "kyc/nigeria/Voters_ID",
-                "kyc/nigeria/BVN_with_face",
-                "kyc/nigeria/Physical_Address_Verification_Lagos",
-                "kyc/nigeria/Physical_Address_Verification_Other",
-                "kyc/nigeria/Physical_Address_Verification_Confirmation"
+                "kyc/nigeria/BVN_with_face"
+                
               ]
             },
             {


### PR DESCRIPTION
This PR :
- removes documentation for implementing the IVS service in countries we no longer offer the service to: Rwanda & Uganda
- removes identity types that are no longer on our service list