### PR TITLE
docs: update face liveness and comparison API documentation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -108,7 +108,7 @@ paths:
               properties:
                 image:
                   type: string
-                  description: URL of the image to check for liveness
+                  description: URL of the live selfie video to check for liveness. Supported formats .mp4, .mov, .webm, .avi, .m4v. Static images are accepted but will perform a self-comparison, not true liveness detection.
       responses:
         "200": { description: Liveness check successful }
         "400": { $ref: "#/components/responses/BadRequest" }

--- a/v1/biometrics/face_comparism.mdx
+++ b/v1/biometrics/face_comparism.mdx
@@ -14,8 +14,8 @@ This can be particularly useful in scenarios such as online payments or identity
 
 ```json
 {
-  "image_one": "https://res.cloudinary.com/dh3i1wodq/image/upload/v1675417496/cbimage_3_drqdoc.jpg",
-  "image_two": "https://res.cloudinary.com/dh3i1wodq/image/upload/v1677955197/face_image_tkmmwz.jpg"
+  "image_url": "https://res.cloudinary.com/dh3i1wodq/image/upload/v1675417496/cbimage_3_drqdoc.jpg",
+  "selfie_url": "https://res.cloudinary.com/dh3i1wodq/image/upload/v1677955197/face_image_tkmmwz.jpg"
 }
 ```
 200 OK Response

--- a/v1/biometrics/face_liveliness.mdx
+++ b/v1/biometrics/face_liveliness.mdx
@@ -1,9 +1,9 @@
 ## Face Liveliness Check
 Face authentication with liveliness check
 
-Liveliness check is a feature that ensures the person being authenticated is physically present and not just a photograph or video.
+Liveliness check ensures the person being authenticated is physically present and not just a photograph or pre-recorded video.
 
-With this endpoint, users can provide their facial features as input to the system, which will then perform a liveliness check to ensure that the user is present and not just a still image or pre-recorded video. This ensures the security and reliability of the authentication process, as it reduces the risk of unauthorized access by fraudulent means.
+Send a **live selfie video** for true liveness detection. The endpoint will run blink and motion analysis on the video to confirm the user is real. If you send a static image, the endpoint will fall back to comparison mode and compare the image to itself, which will always appear to pass but does not prove liveness.
 
 #### Request Endpoint
 
@@ -14,7 +14,7 @@ With this endpoint, users can provide their facial features as input to the syst
 
 ```json
 {
-    "image": " https://res.cloudinary.com/dh3i1wodq/image/upload/v1675417496/cbimage_3_drqdoc.jpg", 
+    "image": "https://res.cloudinary.com/dh3i1wodq/video/upload/v1675417496/selfie_liveness.mp4"
 }
 ```
 

--- a/v3/biometrics/face_comparism.mdx
+++ b/v3/biometrics/face_comparism.mdx
@@ -26,8 +26,8 @@ POST /api/onboarding/biometrics/face/comparison
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `image_one` | string | Yes | URL or base64-encoded string of the first face image |
-| `image_two` | string | Yes | URL or base64-encoded string of the second face image |
+| `image_url` | string | Yes | URL of the reference ID photo or database face image |
+| `selfie_url` | string | Yes | URL of the live selfie to compare against the reference |
 
 ### Example
 
@@ -37,8 +37,8 @@ curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/biometrics/face/
   -H "x-access-token: YOUR_SECRET_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "image_one": "https://example.com/photo1.jpg",
-    "image_two": "https://example.com/photo2.jpg"
+    "image_url": "https://example.com/id_photo.jpg",
+    "selfie_url": "https://example.com/selfie.jpg"
   }'
 ```
 
@@ -52,8 +52,8 @@ const response = await fetch(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      image_one: "https://example.com/photo1.jpg",
-      image_two: "https://example.com/photo2.jpg",
+      image_url: "https://example.com/id_photo.jpg",
+      selfie_url: "https://example.com/selfie.jpg",
     }),
   }
 );
@@ -70,8 +70,8 @@ response = requests.post(
         "Content-Type": "application/json",
     },
     json={
-        "image_one": "https://example.com/photo1.jpg",
-        "image_two": "https://example.com/photo2.jpg",
+        "image_url": "https://example.com/id_photo.jpg",
+        "selfie_url": "https://example.com/selfie.jpg",
     },
 )
 data = response.json()

--- a/v3/biometrics/face_liveliness.mdx
+++ b/v3/biometrics/face_liveliness.mdx
@@ -5,7 +5,9 @@ description: "Verify that a submitted facial image belongs to a live person, not
 openapi: "POST /api/onboarding/biometrics/face/liveliness_check/"
 ---
 
-The Face Liveness Check endpoint analyzes a facial image to confirm physical presence. It returns a confidence score and a verification status to help you distinguish real users from spoofing attempts.
+The Face Liveness Check endpoint analyzes a live selfie video to confirm physical presence. It runs blink and motion analysis on the video to distinguish a real user from a photograph or pre-recorded video, then compares the face in the video to the face in the same video.
+
+For true liveness detection, send a selfie video. Sending a static image will perform a self-comparison, not a liveness check.
 
 ## Endpoint
 
@@ -26,7 +28,7 @@ POST /api/onboarding/biometrics/face/liveliness_check/
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `image` | string | Yes | URL of the facial image to check for liveness |
+| `image` | string | Yes | URL of the live selfie **video** to check for liveness. Supported formats: `.mp4`, `.mov`, `.webm`, `.avi`, `.m4v`. |
 
 ### Example
 
@@ -35,8 +37,12 @@ POST /api/onboarding/biometrics/face/liveliness_check/
 curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/biometrics/face/liveliness_check/" \
   -H "x-access-token: YOUR_SECRET_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"image": "https://example.com/photo.jpg"}'
+  -d '{"image": "https://example.com/selfie_liveness.mp4"}'
 ```
+
+<Note>
+A static image (e.g. `.jpg` or `.png`) will be processed in comparison mode against itself, so it will always appear to pass. For real liveness detection, send a selfie video captured by the user.
+</Note>
 </CodeGroup>
 
 ## Response


### PR DESCRIPTION
- Clarify liveness check requires a live selfie video (mp4/mov/webm/avi/m4v)
- Add note that static images fall back to self-comparison mode
- Rename face comparison params: image_one -> image_url, image_two -> selfie_url
- Update examples across v1 and v3 docs and openapi.yaml