### PR TITLE
docs: fix card fraud check nested structure and replace bvn with iden…

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1388,13 +1388,14 @@ paths:
                   properties:
                     customer_name: { type: string }
                     customer_email: { type: string, format: email }
-                    bvn: { type: string, description: "Customer BVN (Nigeria). Use identifier + identifier_type for other countries" }
                     identifier:
                       type: string
-                      description: Customer identifier for non-Nigeria customers (e.g. national ID)
+                      description: "Customer identifier value. Use bvn for Nigeria, national_id for Kenya, ghana_card for Ghana, etc."
+                      example: "22430372151"
                     identifier_type:
                       type: string
-                      description: "Key of the identifier type (e.g. bvn, national_id, ghana_card)"
+                      description: "Key of the identifier type (e.g. bvn, national_id, ghana_card). Required when identifier is provided"
+                      example: "bvn"
                 additional_info:
                   type: object
                   required: [ip_address, location]
@@ -1423,77 +1424,88 @@ paths:
           application/json:
             schema:
               type: object
-              required: [transaction_id, amount, currency, transaction_type, account_type]
+              required: [transaction_id, amount, currency, transaction_type, account_type, card_details, customer_details, additional_info]
               properties:
                 transaction_id:
                   type: string
-                  description: Unique identifier for the transaction
                   example: "TXN-CARD-12345678"
                 amount:
                   type: number
-                  description: Transaction amount
-                  example: 300000
+                  example: 99.13
                 currency:
                   type: string
-                  description: Currency code
                   example: "NGN"
                 transaction_type:
                   type: string
-                  description: Must be 'card' for card fraud checks
                   example: "card"
                 account_type:
                   type: string
                   enum: [individual, corporate]
-                  example: "individual"
-                card_bin:
+                  example: "corporate"
+                timestamp:
                   type: string
-                  description: First six digits of the card number (BIN)
-                  example: "345676"
-                card_last4:
-                  type: string
-                  description: Last four digits of the card number
-                  example: "9809"
-                customer_name:
-                  type: string
-                  example: "John Doe"
-                customer_email:
-                  type: string
-                  format: email
-                  example: "john.doe@example.com"
-                customer_phone_number:
-                  type: string
-                  example: "+2347012345678"
-                bvn:
-                  type: string
-                  description: Customer's BVN (Nigeria). Use identifier + identifier_type for other countries
-                  example: "12345678901"
-                identifier:
-                  type: string
-                  description: Customer identifier for non-Nigeria customers (e.g. national ID number)
-                  example: "12345678"
-                identifier_type:
-                  type: string
-                  description: "Key of the identifier type (e.g. bvn, national_id, ghana_card). Required when identifier is provided"
-                  example: "national_id"
-                merchant_name:
-                  type: string
-                  example: "ABC Stores"
-                merchant_location:
-                  type: string
-                  example: "Lagos, Nigeria"
-                customer_ip_address:
-                  type: string
-                  example: "102.89.1.1"
-                customer_location:
-                  type: string
-                  example: "Lagos, Nigeria"
-                transaction_date:
-                  type: string
-                  description: "Date of transaction. Formats: DD-MM-YYYY, YYYY-MM-DD HH:MM:SS, or ISO 8601"
+                  description: ISO 8601 transaction timestamp
                   example: "2025-08-23T14:30:00Z"
-                transaction_description:
-                  type: string
-                  example: "Online purchase"
+                card_details:
+                  type: object
+                  required: [bin, last4]
+                  properties:
+                    bin:
+                      type: integer
+                      description: First six digits of the card (BIN)
+                      example: 345676
+                    last4:
+                      type: integer
+                      description: Last four digits of the card
+                      example: 9809
+                merchant_details:
+                  type: object
+                  properties:
+                    merchant_name:
+                      type: string
+                      example: "ABC Stores"
+                    merchant_location:
+                      type: string
+                      example: "Lagos, Nigeria"
+                    merchant_code:
+                      type: string
+                      description: Merchant category code (MCC)
+                      example: "5813"
+                customer_details:
+                  type: object
+                  required: [customer_name, customer_email]
+                  properties:
+                    customer_name:
+                      type: string
+                      example: "Imagine Dragons"
+                    customer_email:
+                      type: string
+                      format: email
+                      example: "imaginedragons@gmail.com"
+                    customer_phone:
+                      type: string
+                      example: "+2347012345678"
+                    identifier:
+                      type: string
+                      description: "Customer identifier value (e.g. BVN for Nigeria, national ID for Kenya)"
+                      example: "98765432109"
+                    identifier_type:
+                      type: string
+                      description: "Key of the identifier type: bvn, national_id, ghana_card, etc."
+                      example: "bvn"
+                additional_info:
+                  type: object
+                  required: [ip_address, location]
+                  properties:
+                    ip_address:
+                      type: string
+                      example: "102.89.1.1"
+                    location:
+                      type: string
+                      example: "Lagos, Nigeria"
+                    transaction_description:
+                      type: string
+                      example: "Online purchase"
       responses:
         "201": { description: Card fraud check processed }
         "400": { $ref: "#/components/responses/BadRequest" }

--- a/v3/transaction/card_transaction/post_fraud_request.mdx
+++ b/v3/transaction/card_transaction/post_fraud_request.mdx
@@ -5,7 +5,7 @@ description: "Submit a card transaction for real-time fraud scoring based on you
 openapi: "POST /api/v1/monitoring/post_monitoring_data/"
 ---
 
-The Card Fraud Detection endpoint evaluates a card transaction in real-time against your configured thresholds and limits. Submit card-specific details including BIN, last 4 digits, merchant info, and customer details. Use a unique `transaction_id` for each request.
+The Card Fraud Detection endpoint evaluates a card transaction in real-time against your configured thresholds and limits. Use a unique `transaction_id` for each request to ensure accurate tracking.
 
 ## Endpoint
 
@@ -27,24 +27,28 @@ POST /api/v1/monitoring/post_monitoring_data/
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `transaction_id` | string | Yes | Unique identifier for the transaction |
-| `amount` | number | Yes | Transaction amount (e.g. `300000` or `"300,000.00"`) |
+| `amount` | number | Yes | Transaction amount (e.g. `99.13`) |
 | `currency` | string | Yes | Currency code (e.g., `NGN`, `USD`) |
 | `transaction_type` | string | Yes | Must be `card` for card fraud checks |
 | `account_type` | string | Yes | `individual` or `corporate` |
-| `card_bin` | string | Yes | First six digits of the card number (BIN) |
-| `card_last4` | string | Yes | Last four digits of the card number |
-| `customer_name` | string | Yes | Customer's full name |
-| `customer_email` | string | Yes | Customer's email address |
-| `customer_phone_number` | string | No | Customer's phone number |
-| `bvn` | string | No | Customer's Bank Verification Number (Nigeria). Use `identifier` + `identifier_type` for other countries |
-| `identifier` | string | No | Customer's identifier value — use this instead of `bvn` for non-Nigeria customers (e.g. a Kenya national ID number) |
-| `identifier_type` | string | No | The key of the identifier type (e.g. `bvn`, `national_id`, `ghana_card`). Must be provided when `identifier` is provided |
-| `merchant_name` | string | No | Name of the merchant |
-| `merchant_location` | string | No | Location of the merchant |
-| `customer_ip_address` | string | No | IP address during the transaction |
-| `customer_location` | string | No | Customer's location (e.g., `Lagos, Nigeria`) |
-| `transaction_date` | string | No | Date of transaction (formats: `DD-MM-YYYY`, `YYYY-MM-DD HH:MM:SS`, or ISO 8601) |
-| `transaction_description` | string | No | Optional description of the transaction |
+| `timestamp` | string | No | ISO 8601 transaction timestamp |
+| `card_details` | object | Yes | Card-specific information |
+| `card_details.bin` | integer | Yes | First six digits of the card number (BIN) |
+| `card_details.last4` | integer | Yes | Last four digits of the card number |
+| `merchant_details` | object | No | Merchant information |
+| `merchant_details.merchant_name` | string | No | Name of the merchant |
+| `merchant_details.merchant_location` | string | No | Location of the merchant |
+| `merchant_details.merchant_code` | string | No | Merchant category code (MCC) |
+| `customer_details` | object | Yes | Customer information |
+| `customer_details.customer_name` | string | Yes | Customer's full name |
+| `customer_details.customer_email` | string | Yes | Customer's email address |
+| `customer_details.customer_phone` | string | No | Customer's phone number |
+| `customer_details.identifier` | string | No | Customer's identifier value. Use `identifier_type` to specify the type (e.g. BVN for Nigeria, national ID for Kenya) |
+| `customer_details.identifier_type` | string | No | Key of the identifier type: `bvn`, `national_id`, `ghana_card`, etc. Required when `identifier` is provided |
+| `additional_info` | object | Yes | Additional context for fraud evaluation |
+| `additional_info.ip_address` | string | Yes | IP address during the transaction |
+| `additional_info.location` | string | Yes | Location of the transaction (e.g., `"Lagos, Nigeria"`) |
+| `additional_info.transaction_description` | string | No | Optional description of the transaction |
 
 ### Example
 
@@ -55,21 +59,32 @@ curl -X POST "https://adhere-api.smartcomply.com/api/v1/monitoring/post_monitori
   -H "Content-Type: application/json" \
   -d '{
     "transaction_id": "TXN-CARD-12345678",
-    "amount": 300000,
+    "amount": 99.13,
     "currency": "NGN",
     "transaction_type": "card",
-    "account_type": "individual",
-    "card_bin": "345676",
-    "card_last4": "9809",
-    "customer_name": "John Doe",
-    "customer_email": "john.doe@example.com",
-    "customer_phone_number": "+2347012345678",
-    "bvn": "12345678901",
-    "merchant_name": "ABC Stores",
-    "merchant_location": "Lagos, Nigeria",
-    "customer_ip_address": "102.89.1.1",
-    "customer_location": "Lagos, Nigeria",
-    "transaction_date": "2025-08-23T14:30:00Z"
+    "account_type": "corporate",
+    "timestamp": "2025-08-23T14:30:00Z",
+    "card_details": {
+      "bin": 345676,
+      "last4": 9809
+    },
+    "merchant_details": {
+      "merchant_name": "ABC Stores",
+      "merchant_location": "Lagos, Nigeria",
+      "merchant_code": "5813"
+    },
+    "customer_details": {
+      "customer_name": "Imagine Dragons",
+      "customer_email": "imaginedragons@gmail.com",
+      "customer_phone": "+2347012345678",
+      "identifier": "98765432109",
+      "identifier_type": "bvn"
+    },
+    "additional_info": {
+      "ip_address": "102.89.1.1",
+      "location": "Lagos, Nigeria",
+      "transaction_description": "Online purchase"
+    }
   }'
 ```
 
@@ -84,19 +99,32 @@ const response = await fetch(
     },
     body: JSON.stringify({
       transaction_id: "TXN-CARD-12345678",
-      amount: 300000,
+      amount: 99.13,
       currency: "NGN",
       transaction_type: "card",
-      account_type: "individual",
-      card_bin: "345676",
-      card_last4: "9809",
-      customer_name: "John Doe",
-      customer_email: "john.doe@example.com",
-      bvn: "12345678901",
-      merchant_name: "ABC Stores",
-      merchant_location: "Lagos, Nigeria",
-      customer_location: "Lagos, Nigeria",
-      transaction_date: "2025-08-23T14:30:00Z",
+      account_type: "corporate",
+      timestamp: "2025-08-23T14:30:00Z",
+      card_details: {
+        bin: 345676,
+        last4: 9809,
+      },
+      merchant_details: {
+        merchant_name: "ABC Stores",
+        merchant_location: "Lagos, Nigeria",
+        merchant_code: "5813",
+      },
+      customer_details: {
+        customer_name: "Imagine Dragons",
+        customer_email: "imaginedragons@gmail.com",
+        customer_phone: "+2347012345678",
+        identifier: "98765432109",
+        identifier_type: "bvn",
+      },
+      additional_info: {
+        ip_address: "102.89.1.1",
+        location: "Lagos, Nigeria",
+        transaction_description: "Online purchase",
+      },
     }),
   }
 );
@@ -114,19 +142,32 @@ response = requests.post(
     },
     json={
         "transaction_id": "TXN-CARD-12345678",
-        "amount": 300000,
+        "amount": 99.13,
         "currency": "NGN",
         "transaction_type": "card",
-        "account_type": "individual",
-        "card_bin": "345676",
-        "card_last4": "9809",
-        "customer_name": "John Doe",
-        "customer_email": "john.doe@example.com",
-        "bvn": "12345678901",
-        "merchant_name": "ABC Stores",
-        "merchant_location": "Lagos, Nigeria",
-        "customer_location": "Lagos, Nigeria",
-        "transaction_date": "2025-08-23T14:30:00Z",
+        "account_type": "corporate",
+        "timestamp": "2025-08-23T14:30:00Z",
+        "card_details": {
+            "bin": 345676,
+            "last4": 9809,
+        },
+        "merchant_details": {
+            "merchant_name": "ABC Stores",
+            "merchant_location": "Lagos, Nigeria",
+            "merchant_code": "5813",
+        },
+        "customer_details": {
+            "customer_name": "Imagine Dragons",
+            "customer_email": "imaginedragons@gmail.com",
+            "customer_phone": "+2347012345678",
+            "identifier": "98765432109",
+            "identifier_type": "bvn",
+        },
+        "additional_info": {
+            "ip_address": "102.89.1.1",
+            "location": "Lagos, Nigeria",
+            "transaction_description": "Online purchase",
+        },
     },
 )
 data = response.json()
@@ -134,7 +175,7 @@ data = response.json()
 </CodeGroup>
 
 <Note>
-For non-Nigeria customers, omit `bvn` and use `identifier` + `identifier_type` instead. For example, a Kenyan customer would pass `"identifier": "12345678"` and `"identifier_type": "national_id"`.
+Use `identifier` + `identifier_type` inside `customer_details` to pass the customer's ID. For Nigeria use `"identifier_type": "bvn"`, for Kenya use `"identifier_type": "national_id"`, for Ghana use `"identifier_type": "ghana_card"`.
 </Note>
 
 ## Response
@@ -143,7 +184,7 @@ For non-Nigeria customers, omit `bvn` and use `identifier` + `identifier_type` i
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `data.activity_code` | string | Activity code from the fraud assessment (see [activity codes](/v3/transaction/card_transaction/card_transaction_overview)) |
+| `data.activity_code` | string | Activity code from the fraud assessment |
 | `data.status` | string | `"clean"` or `"suspicious"` |
 | `data.comment` | array | List of triggered fraud rules, if any |
 

--- a/v3/transaction/transaction_monitoring/post_transaction_request.mdx
+++ b/v3/transaction/transaction_monitoring/post_transaction_request.mdx
@@ -40,9 +40,8 @@ POST /api/v1/monitoring/transaction_monitoring/
 | `customer_details` | object | Yes | Details of the customer initiating the transaction |
 | `customer_details.customer_name` | string | Yes | Customer's full name |
 | `customer_details.customer_email` | string | Yes | Customer's email address |
-| `customer_details.bvn` | string | No | Customer's BVN (Nigeria). Use `identifier` + `identifier_type` for non-Nigeria customers |
-| `customer_details.identifier` | string | No | Customer identifier for non-Nigeria customers (e.g. a Kenya national ID number) |
-| `customer_details.identifier_type` | string | No | Key of the identifier type (e.g. `bvn`, `national_id`, `ghana_card`). Required when `identifier` is provided |
+| `customer_details.identifier` | string | No | Customer's identifier value. Pass the BVN for Nigeria, national ID for Kenya, Ghana card for Ghana, etc. |
+| `customer_details.identifier_type` | string | No | Key of the identifier type. Use `bvn` for Nigeria, `national_id` for Kenya, `ghana_card` for Ghana, etc. Required when `identifier` is provided |
 | `additional_info` | object | Yes | Additional context for fraud evaluation |
 | `additional_info.ip_address` | string | Yes | IP address during the transaction |
 | `additional_info.location` | string | Yes | Location string or lat/lon (e.g., `"lat=-30.66,lon=-65.77"`) |
@@ -73,7 +72,8 @@ curl -X POST "https://adhere-api.smartcomply.com/api/v1/monitoring/transaction_m
     "customer_details": {
       "customer_name": "Muhammad Ibrahim Isah",
       "customer_email": "user@example.com",
-      "bvn": "22430372151"
+      "identifier": "22430372151",
+      "identifier_type": "bvn"
     },
     "additional_info": {
       "ip_address": "192.168.1.1",
@@ -86,7 +86,7 @@ curl -X POST "https://adhere-api.smartcomply.com/api/v1/monitoring/transaction_m
 </CodeGroup>
 
 <Note>
-For non-Nigeria customers, omit `bvn` and pass `identifier` (the ID value) and `identifier_type` (the key, e.g. `national_id`, `ghana_card`) inside `customer_details` instead. This enables multi-country customer risk profiling.
+Always use `identifier` and `identifier_type` inside `customer_details` to pass the customer's ID. For Nigeria pass `"identifier_type": "bvn"`, for Kenya pass `"identifier_type": "national_id"`, for Ghana pass `"identifier_type": "ghana_card"`, and so on. There is no separate `bvn` field.
 </Note>
 
 ## Response


### PR DESCRIPTION
…tifier fields

- Restructure card fraud check payload to use correct nested objects: card_details (bin, last4), merchant_details (merchant_name, merchant_location, merchant_code), customer_details, additional_info
- Remove flat card_bin, card_last4, merchant_name, merchant_location fields — all now correctly nested
- Add timestamp field to card fraud check
- Replace standalone bvn field with identifier + identifier_type in both card fraud check and transaction monitoring customer_details
- Update all code examples (cURL, Node.js, Python) with correct structure
- Update openapi.yaml sidebar schema to match nested structure
- Update notes to clarify identifier_type usage per country