### PR TITLE
docs: hide Flutter SDK page from navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -80,7 +80,6 @@
                   "libraries/smartcomply_sdk",
                   "libraries/android_sdk",
                   "libraries/ios_sdk",
-                  "libraries/flutter_sdk",
                   "libraries/postman"
                 ]
               },
@@ -260,7 +259,7 @@
               },
               {
                 "group": "Libraries",
-                "pages": ["libraries/smartcomply_sdk", "libraries/android_sdk", "libraries/ios_sdk", "libraries/flutter_sdk"]
+                "pages": ["libraries/smartcomply_sdk", "libraries/android_sdk", "libraries/ios_sdk"]
               },
               {
                 "group": "Onboarding Suite",
@@ -430,7 +429,7 @@
               },
               {
                 "group": "Libraries",
-                "pages": ["libraries/smartcomply_sdk", "libraries/android_sdk", "libraries/ios_sdk", "libraries/flutter_sdk"]
+                "pages": ["libraries/smartcomply_sdk", "libraries/android_sdk", "libraries/ios_sdk"]
               },
               {
                 "group": "Biometrics",


### PR DESCRIPTION
Flutter SDK isn't available yet — remove it from all three nav groups (docs.json) so it doesn't show up as a selectable option. The page file itself (libraries/flutter_sdk.mdx) is left in place, unlinked, in case it's needed again later.