### PR TITLE
docs: fix TIN format to company TIN, not individual

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -383,8 +383,8 @@ paths:
               properties:
                 tax_identification_number:
                   type: string
-                  description: "The customer's TIN (format: N-XXXXXXXX)"
-                  example: "N-01234567"
+                  description: "The company's Tax Identification Number (format: 234123456-0001, 8-14 digits)"
+                  example: "234123456-0001"
       responses:
         "200": { description: TIN verified }
         "400": { $ref: "#/components/responses/BadRequest" }

--- a/v1/kyc/nigeria/tin.mdx
+++ b/v1/kyc/nigeria/tin.mdx
@@ -11,9 +11,11 @@ You can verify your customers' identity using their Tax Identification Number (T
 
 ```json
 {
-    "tax_identification_number": "N-01234567"
+    "tax_identification_number": "234123456-0001"
 }
 ```
+
+The `tax_identification_number` must be the company's TIN (format: `234123456-0001`, 8-14 digits). The individual TIN format (`N-XXXXXXXX`) is not supported.
 
 200 OK Response
 

--- a/v2/kyc/nigeria/tin.mdx
+++ b/v2/kyc/nigeria/tin.mdx
@@ -14,9 +14,11 @@ You can verify your customers' identity using their Tax Identification Number (T
 
 ```json
 {
-    "tax_identification_number": "N-01234567"
+    "tax_identification_number": "234123456-0001"
 }
 ```
+
+The `tax_identification_number` must be the company's TIN (format: `234123456-0001`, 8-14 digits). The individual TIN format (`N-XXXXXXXX`) is not supported.
 
 200 OK Response
 

--- a/v3/kyc/nigeria/tin.mdx
+++ b/v3/kyc/nigeria/tin.mdx
@@ -26,7 +26,7 @@ POST /api/onboarding/nigeria_kyc/tin/
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `tax_identification_number` | string | Yes | The customer's TIN (format: `N-XXXXXXXX`) |
+| `tax_identification_number` | string | Yes | The company's Tax Identification Number (format: `234123456-0001`, 8-14 digits) |
 
 ### Example
 
@@ -35,7 +35,7 @@ POST /api/onboarding/nigeria_kyc/tin/
 curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/nigeria_kyc/tin/" \
   -H "x-access-token: YOUR_SECRET_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"tax_identification_number": "N-01234567"}'
+  -d '{"tax_identification_number": "234123456-0001"}'
 ```
 
 ```python Python
@@ -43,7 +43,7 @@ import requests
 response = requests.post(
     "https://adhere-api.smartcomply.com/api/onboarding/nigeria_kyc/tin/",
     headers={"x-access-token": "YOUR_SECRET_KEY", "Content-Type": "application/json"},
-    json={"tax_identification_number": "N-01234567"},
+    json={"tax_identification_number": "234123456-0001"},
 )
 ```
 </CodeGroup>


### PR DESCRIPTION
The individual TIN format (N-XXXXXXXX) shown in the docs isn't supported by the backend — only business/company TINs (8-14 digits, e.g. 234123456-0001) are validated. Updates v1-v3 tin.mdx and openapi.yaml to reflect the actual accepted format.