### PR TITLE
docs: flag Passport as unavailable, note TIN is business-only

### DIFF
--- a/v1/kyc/nigeria/passport_verification.mdx
+++ b/v1/kyc/nigeria/passport_verification.mdx
@@ -1,3 +1,7 @@
+<Warning>
+  This service is not available at the moment. We're working to restore it — please check back soon.
+</Warning>
+
 ## Verify your customers' identities using their passport identification numbers.
 
 Adhere's passport validity check endpoint provides access to verified national-level information, ensuring accurate and reliable identity verification.

--- a/v1/kyc/nigeria/tin.mdx
+++ b/v1/kyc/nigeria/tin.mdx
@@ -1,5 +1,9 @@
 # Verify Customer Identity Using Their Tax Identification Number (TIN)
 
+<Note>
+  This service only works for company/business TIN. Individual TIN lookups are not supported.
+</Note>
+
 You can verify your customers' identity using their Tax Identification Number (TIN) through the API.
 
 #### Request Endpoint

--- a/v2/kyc/nigeria/passport_verification.mdx
+++ b/v2/kyc/nigeria/passport_verification.mdx
@@ -1,6 +1,11 @@
 ---
 sidebarTitle: "Passport"
 ---
+
+<Warning>
+  This service is not available at the moment. We're working to restore it — please check back soon.
+</Warning>
+
 ## Verify your customers' identities using their passport identification numbers.
 
 Adhere's passport validity check endpoint provides access to verified national-level information, ensuring accurate and reliable identity verification.

--- a/v2/kyc/nigeria/tin.mdx
+++ b/v2/kyc/nigeria/tin.mdx
@@ -3,6 +3,10 @@ sidebarTitle: "Tax Identification Number (TIN)"
 ---
 # Verify Customer Identity Using Their Tax Identification Number (TIN)
 
+<Note>
+  This service only works for company/business TIN. Individual TIN lookups are not supported.
+</Note>
+
 You can verify your customers' identity using their Tax Identification Number (TIN) through the API.
 
 #### Request Endpoint

--- a/v3/kyc/nigeria/passport_verification.mdx
+++ b/v3/kyc/nigeria/passport_verification.mdx
@@ -5,6 +5,10 @@ description: "Verify a customer's identity using their Nigerian international pa
 openapi: "POST /api/onboarding/nigeria_kyc/passport/"
 ---
 
+<Warning>
+  This service is not available at the moment. We're working to restore it — please check back soon.
+</Warning>
+
 The Passport Verification endpoint validates a Nigerian passport number against the government database and returns the holder's personal details, passport validity dates, and a photo.
 
 ## Endpoint

--- a/v3/kyc/nigeria/tin.mdx
+++ b/v3/kyc/nigeria/tin.mdx
@@ -5,6 +5,10 @@ description: "Verify a customer's identity using their Nigerian Tax Identificati
 openapi: "POST /api/onboarding/nigeria_kyc/tin/"
 ---
 
+<Note>
+  This service only works for company/business TIN. Individual TIN lookups are not supported.
+</Note>
+
 The TIN endpoint validates a Tax Identification Number against the FIRS (Federal Inland Revenue Service) database and returns the associated taxpayer name, CAC registration number, tax office, and contact details.
 
 ## Endpoint


### PR DESCRIPTION
Passport Verification has gone down alongside the other 4 flagged services, so it gets the same Warning callout. TIN already restricted lookups to company TIN in prose but it was easy to miss; adding a visible Note so clients don't attempt individual TIN checks.