### PR TITLE
docs: fix field gaps found auditing document verification pages again…

### DIFF
--- a/v3/kyc/document_verification/canada/Passport.mdx
+++ b/v3/kyc/document_verification/canada/Passport.mdx
@@ -97,12 +97,13 @@ data = response.json()
 | `data.last_name` | string | Extracted last name |
 | `data.date_of_birth` | string | Date of birth in `YYYY-MM-DD` format |
 | `data.gender` | string | Extracted gender |
+| `data.nationality` | string | Extracted nationality |
 | `data.id_number` | string | The passport number |
 | `data.document_type` | string | `"passport"` |
 | `data.expiry_date` | string | Passport expiry date |
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
-| `data.extra_fields` | object | Present if OCR could read the machine-readable zone — `mrz_line1`/`mrz_line2`, exactly as printed |
+| `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, `nin` (if embedded), and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
 | `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
@@ -119,12 +120,18 @@ data = response.json()
     "last_name": "TREMBLAY",
     "full_name": "TREMBLAY JAMES",
     "date_of_birth": "1988-07-22",
+    "gender": "M",
+    "nationality": "CANADIAN",
     "id_number": "GA123456",
     "id_type": "passport",
     "document_type": "passport",
     "expiry_date": "2027-09-30",
     "is_expired": false,
     "photo": "/9j/4AAQSkZJRgABAQAAAQABAAD...",
+    "extra_fields": {
+      "place_of_birth": "TORONTO, ON",
+      "issuing_authority": "GATINEAU, QC"
+    },
     "face_match": {
       "attempted": true,
       "verified": true,

--- a/v3/kyc/document_verification/cote_d_ivoire/Passport.mdx
+++ b/v3/kyc/document_verification/cote_d_ivoire/Passport.mdx
@@ -97,12 +97,13 @@ data = response.json()
 | `data.last_name` | string | Extracted last name |
 | `data.date_of_birth` | string | Date of birth in `YYYY-MM-DD` format |
 | `data.gender` | string | Extracted gender |
+| `data.nationality` | string | Extracted nationality |
 | `data.id_number` | string | The passport number |
 | `data.document_type` | string | `"passport"` |
 | `data.expiry_date` | string | Passport expiry date |
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
-| `data.extra_fields` | object | Present if OCR could read the machine-readable zone — `mrz_line1`/`mrz_line2`, exactly as printed |
+| `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, `nin` (if embedded), and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
 | `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
@@ -119,12 +120,18 @@ data = response.json()
     "last_name": "YAO",
     "full_name": "YAO KOFFI",
     "date_of_birth": "1993-12-01",
+    "gender": "M",
+    "nationality": "IVORIAN",
     "id_number": "CI1234567",
     "id_type": "passport",
     "document_type": "passport",
     "expiry_date": "2028-03-17",
     "is_expired": false,
     "photo": "/9j/4AAQSkZJRgABAQAAAQABAAD...",
+    "extra_fields": {
+      "place_of_birth": "ABIDJAN",
+      "issuing_authority": "ABIDJAN"
+    },
     "face_match": {
       "attempted": true,
       "verified": true,

--- a/v3/kyc/document_verification/ghana/Passport.mdx
+++ b/v3/kyc/document_verification/ghana/Passport.mdx
@@ -97,12 +97,13 @@ data = response.json()
 | `data.last_name` | string | Extracted last name |
 | `data.date_of_birth` | string | Date of birth in `YYYY-MM-DD` format |
 | `data.gender` | string | Extracted gender |
+| `data.nationality` | string | Extracted nationality |
 | `data.id_number` | string | The passport number |
 | `data.document_type` | string | `"passport"` |
 | `data.expiry_date` | string | Passport expiry date |
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
-| `data.extra_fields` | object | Present if OCR could read the machine-readable zone — `mrz_line1`/`mrz_line2`, exactly as printed |
+| `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, `nin` (if embedded), and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
 | `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
@@ -119,12 +120,18 @@ data = response.json()
     "last_name": "MENSAH",
     "full_name": "MENSAH KWAME",
     "date_of_birth": "1992-11-04",
+    "gender": "M",
+    "nationality": "GHANAIAN",
     "id_number": "G1234567",
     "id_type": "passport",
     "document_type": "passport",
     "expiry_date": "2028-02-20",
     "is_expired": false,
     "photo": "/9j/4AAQSkZJRgABAQAAAQABAAD...",
+    "extra_fields": {
+      "place_of_birth": "ACCRA",
+      "issuing_authority": "ACCRA"
+    },
     "face_match": {
       "attempted": true,
       "verified": true,

--- a/v3/kyc/document_verification/kenya/Kenya_ID.mdx
+++ b/v3/kyc/document_verification/kenya/Kenya_ID.mdx
@@ -103,6 +103,10 @@ data = response.json()
 | `data.gender` | string | Extracted gender |
 | `data.id_number` | string | The ID number |
 | `data.document_type` | string | `"kenya_id"` |
+| `data.expiry_date` | string | Maisha Card expiry date — only present on third-generation cards |
+| `data.issue_date` | string | Date of issue |
+| `data.place_of_issue` | string | Only present on third-generation "Maisha Card" IDs |
+| `data.serial_number` | string | Separate 9-digit card serial number — only present on third-generation "Maisha Card" IDs |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
 | `data.extra_fields` | object | Other fields printed on the card — see below |
 | `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
@@ -124,6 +128,9 @@ data = response.json()
     "id_number": "34567890",
     "id_type": "kenya_id",
     "document_type": "kenya_id",
+    "issue_date": "2019-05-14",
+    "place_of_issue": "NAIROBI",
+    "serial_number": "123456789",
     "photo": "/9j/4AAQSkZJRgABAQAAAQABAAD...",
     "extra_fields": {
       "district_of_birth": "NAIROBI",
@@ -131,7 +138,10 @@ data = response.json()
       "division": "CENTRAL",
       "location": "NAIROBI CENTRAL",
       "sub_location": "CBD",
-      "barcode_number": "12345678"
+      "barcode_number": "12345678",
+      "mrz_line1": "IDKEN3456789012<<<<<<<<<<<<<<<",
+      "mrz_line2": "9503109F2905147KEN<<<<<<<<<<<8",
+      "mrz_line3": "KAMAU<<WANJIRU<<<<<<<<<<<<<<<<"
     },
     "face_match": {
       "attempted": true,
@@ -145,7 +155,7 @@ data = response.json()
 ```
 
 <Note>
-  **Extra Fields** — `extra_fields` carries whatever else the card printed beyond the fields listed above. Fields specific to the newer "Maisha Card" design (`serial_number`, `place_of_issue`, `date_of_expiry`) are top-level fields when present; back-side fields (`district`, `division`, `location`, `sub_location`, `barcode_number`) land in `extra_fields`. Only fields actually present on the card are included.
+  **Extra Fields** — `extra_fields` carries whatever else the card printed beyond the fields listed above: `district_of_birth`, and — only when `document_back` was supplied — `district`, `division`, `location`, `sub_location`, `barcode_number`, and the three MRZ lines (`mrz_line1`/`mrz_line2`/`mrz_line3`, exactly as printed, including `<` fill characters — not decoded). Only fields actually present on the card are included.
 </Note>
 
 <Note>

--- a/v3/kyc/document_verification/kenya/Passport.mdx
+++ b/v3/kyc/document_verification/kenya/Passport.mdx
@@ -97,12 +97,13 @@ data = response.json()
 | `data.last_name` | string | Extracted last name |
 | `data.date_of_birth` | string | Date of birth in `YYYY-MM-DD` format |
 | `data.gender` | string | Extracted gender |
+| `data.nationality` | string | Extracted nationality |
 | `data.id_number` | string | The passport number |
 | `data.document_type` | string | `"passport"` |
 | `data.expiry_date` | string | Passport expiry date |
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
-| `data.extra_fields` | object | Present if OCR could read the machine-readable zone — `mrz_line1`/`mrz_line2`, exactly as printed |
+| `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, `nin` (if embedded), and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
 | `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
@@ -119,12 +120,18 @@ data = response.json()
     "last_name": "KAMAU",
     "full_name": "KAMAU WANJIRU",
     "date_of_birth": "1995-03-10",
+    "gender": "F",
+    "nationality": "KENYAN",
     "id_number": "K1234567",
     "id_type": "passport",
     "document_type": "passport",
     "expiry_date": "2029-08-15",
     "is_expired": false,
     "photo": "/9j/4AAQSkZJRgABAQAAAQABAAD...",
+    "extra_fields": {
+      "place_of_birth": "NAIROBI",
+      "issuing_authority": "NAIROBI"
+    },
     "face_match": {
       "attempted": true,
       "verified": true,

--- a/v3/kyc/document_verification/nigeria/CAC_Certificate.mdx
+++ b/v3/kyc/document_verification/nigeria/CAC_Certificate.mdx
@@ -5,7 +5,7 @@ description: "Extract business registration details from a CAC Certificate of In
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a business's CAC Certificate of Incorporation by uploading a photo — no manual RC number entry required. OCR extraction only. This document doesn't carry a face photo, so `data.photo` is always `null` — face match isn't available for this document type; a `selfie_image` submitted alongside it is accepted but ignored (`face_match.attempted: false`).
+Verify a business's CAC Certificate of Incorporation by uploading a photo — no manual RC number entry required. OCR extraction only. This document doesn't carry a face photo, so `data.photo` is omitted from the response entirely — face match isn't available for this document type; a `selfie_image` submitted alongside it is accepted but ignored (`face_match.attempted: false`).
 
 <Note>
   Only `document_front` is needed for this document.
@@ -83,11 +83,15 @@ data = response.json()
 |-------|------|--------------|
 | `status` | string | `"success"` on a successful extraction |
 | `data.full_name` | string | Registered business name |
+| `data.address` | string | Registered business address |
 | `data.id_number` | string | RC/BN registration number |
 | `data.document_type` | string | `"cac_certificate"` |
-| `data.photo` | string | Always `null` — CAC certificates don't carry a face |
 | `data.extra_fields` | object | Other fields printed on the certificate — see below |
 | `message` | string | Human-readable result summary |
+
+<Note>
+  `data.photo` is never present for this document type — CAC certificates don't carry a face, and fields with no value are omitted from the response rather than sent as `null`. The same applies to `face_match`: it's included only when `selfie_image` was supplied, and even then always comes back `attempted: false` for this document type.
+</Note>
 
 ```json
 {
@@ -95,10 +99,10 @@ data = response.json()
   "data": {
     "valid": true,
     "full_name": "FISAYOMI KAYODE NIG LTD",
+    "address": "12 CORPORATE DRIVE, VICTORIA ISLAND, LAGOS",
     "id_number": "RC012345",
     "id_type": "cac_certificate",
     "document_type": "cac_certificate",
-    "photo": null,
     "extra_fields": {
       "business_type": "LIMITED LIABILITY COMPANY",
       "date_of_incorporation": "2015-06-10",

--- a/v3/kyc/document_verification/nigeria/Passport.mdx
+++ b/v3/kyc/document_verification/nigeria/Passport.mdx
@@ -97,12 +97,13 @@ data = response.json()
 | `data.last_name` | string | Extracted last name |
 | `data.date_of_birth` | string | Date of birth in `YYYY-MM-DD` format |
 | `data.gender` | string | Extracted gender |
+| `data.nationality` | string | Extracted nationality |
 | `data.id_number` | string | The passport number |
 | `data.document_type` | string | `"passport"` |
 | `data.expiry_date` | string | Passport expiry date |
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
-| `data.extra_fields` | object | Present if OCR could read the machine-readable zone — `mrz_line1`/`mrz_line2`, exactly as printed |
+| `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, `nin` (if embedded), and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
 | `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
@@ -119,12 +120,18 @@ data = response.json()
     "last_name": "AYODELE",
     "full_name": "AYODELE TUNDE",
     "date_of_birth": "2002-02-16",
+    "gender": "M",
+    "nationality": "NIGERIAN",
     "id_number": "A12345678",
     "id_type": "passport",
     "document_type": "passport",
     "expiry_date": "2030-01-01",
     "is_expired": false,
     "photo": "/9j/4AAQSkZJRgABAQAAAQABAAD...",
+    "extra_fields": {
+      "place_of_birth": "LAGOS",
+      "issuing_authority": "IKOYI, LAGOS"
+    },
     "face_match": {
       "attempted": true,
       "verified": true,

--- a/v3/kyc/document_verification/nigeria/Utility_Bill.mdx
+++ b/v3/kyc/document_verification/nigeria/Utility_Bill.mdx
@@ -5,7 +5,7 @@ description: "Extract address and biller details from a utility bill using OCR."
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a customer's proof of address by uploading a photo of a utility bill — no manual data entry required. OCR extraction only. This document doesn't carry a face photo, so `data.photo` is always `null` — face match isn't available for this document type; a `selfie_image` submitted alongside it is accepted but ignored (`face_match.attempted: false`).
+Verify a customer's proof of address by uploading a photo of a utility bill — no manual data entry required. OCR extraction only. This document doesn't carry a face photo, so `data.photo` is omitted from the response entirely — face match isn't available for this document type; a `selfie_image` submitted alongside it is accepted but ignored (`face_match.attempted: false`).
 
 <Note>
   Only `document_front` is needed for this document.
@@ -84,10 +84,14 @@ data = response.json()
 | `status` | string | `"success"` on a successful extraction |
 | `data.full_name` | string | Name on the bill |
 | `data.address` | string | Extracted billing address |
+| `data.id_number` | string | Account number printed on the bill |
 | `data.document_type` | string | `"utility_bill"` |
-| `data.photo` | string | Always `null` — utility bills don't carry a face |
 | `data.extra_fields` | object | Other fields printed on the bill — see below |
 | `message` | string | Human-readable result summary |
+
+<Note>
+  `data.photo` is never present for this document type — utility bills don't carry a face, and fields with no value are omitted from the response rather than sent as `null`. The same applies to `face_match`: it's included only when `selfie_image` was supplied, and even then always comes back `attempted: false` for this document type.
+</Note>
 
 ```json
 {
@@ -96,9 +100,9 @@ data = response.json()
     "valid": true,
     "full_name": "AYODELE TUNDE",
     "address": "12 Adeola Odeku Street, Victoria Island, Lagos",
+    "id_number": "1234567890",
     "id_type": "utility_bill",
     "document_type": "utility_bill",
-    "photo": null,
     "extra_fields": {
       "issuer_name": "IKEJA ELECTRIC",
       "billing_period": "July 2026"

--- a/v3/kyc/document_verification/nigeria/Voters_Card.mdx
+++ b/v3/kyc/document_verification/nigeria/Voters_Card.mdx
@@ -97,7 +97,9 @@ data = response.json()
 | `data.last_name` | string | Extracted last name |
 | `data.date_of_birth` | string | Date of birth in `YYYY-MM-DD` format |
 | `data.gender` | string | Extracted gender |
+| `data.address` | string | Registered address printed on the card |
 | `data.id_number` | string | The Voter Identification Number (VIN) |
+| `data.serial_number` | string | The card's serial number |
 | `data.document_type` | string | `"voters_card"` |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
 | `data.extra_fields` | object | Other fields printed on the card — see below |
@@ -117,7 +119,10 @@ data = response.json()
     "last_name": "AYODELE",
     "full_name": "AYODELE TUNDE",
     "date_of_birth": "2002-02-16",
+    "gender": "M",
+    "address": "12 ALLEN AVENUE, IKEJA, LAGOS",
     "id_number": "90F5A1B2C3D4E5F6",
+    "serial_number": "SN00123456",
     "id_type": "voters_card",
     "document_type": "voters_card",
     "photo": "/9j/4AAQSkZJRgABAQAAAQABAAD...",
@@ -127,8 +132,7 @@ data = response.json()
       "lga": "IKEJA",
       "ward": "WARD 5",
       "polling_unit_code": "PU001234",
-      "date_of_registration": "2019-01-15",
-      "batch_number": "B00123"
+      "date_of_registration": "2019-01-15"
     },
     "face_match": {
       "attempted": true,

--- a/v3/kyc/document_verification/usa/Passport.mdx
+++ b/v3/kyc/document_verification/usa/Passport.mdx
@@ -97,12 +97,13 @@ data = response.json()
 | `data.last_name` | string | Extracted last name |
 | `data.date_of_birth` | string | Date of birth in `YYYY-MM-DD` format |
 | `data.gender` | string | Extracted gender |
+| `data.nationality` | string | Extracted nationality |
 | `data.id_number` | string | The passport number |
 | `data.document_type` | string | `"passport"` |
 | `data.expiry_date` | string | Passport expiry date |
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
-| `data.extra_fields` | object | Present if OCR could read the machine-readable zone — `mrz_line1`/`mrz_line2`, exactly as printed |
+| `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, `nin` (if embedded), and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
 | `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
@@ -119,12 +120,18 @@ data = response.json()
     "last_name": "JOHNSON",
     "full_name": "JOHNSON MICHAEL",
     "date_of_birth": "1991-04-18",
+    "gender": "M",
+    "nationality": "USA",
     "id_number": "543219876",
     "id_type": "passport",
     "document_type": "passport",
     "expiry_date": "2029-06-12",
     "is_expired": false,
     "photo": "/9j/4AAQSkZJRgABAQAAAQABAAD...",
+    "extra_fields": {
+      "place_of_birth": "CALIFORNIA, USA",
+      "issuing_authority": "UNITED STATES DEPARTMENT OF STATE"
+    },
     "face_match": {
       "attempted": true,
       "verified": true,


### PR DESCRIPTION
…st real code/payloads

- All 6 passport pages (Nigeria, Kenya, Ghana, USA, Canada, Côte d'Ivoire): add missing data.nationality (top-level field), and correct extra_fields to list place_of_birth/issuing_authority/nin — confirmed real via an actual production response, not just code inspection.
- Nigeria Voter's Card: add missing data.gender, data.address, data.serial_number (all real top-level fields per document_ocr.py's canonical mapping) — serial_number was incorrectly shown folded into extra_fields.batch_number instead of its own field.
- Nigeria CAC Certificate: add missing data.address; correct data.photo from "always null" to "omitted" — the endpoint uses model_dump(exclude_none=True), so a None field never appears as null in the response, it's absent entirely.
- Nigeria Utility Bill: same data.photo correction; add missing data.id_number (account number).
- Kenya National ID: add missing data.expiry_date/issue_date/ place_of_issue/serial_number top-level fields (Maisha Card only), and the three MRZ lines that land in extra_fields when document_back is supplied — both confirmed against OCR_USER_GUIDE.md.