### PR TITLE
docs: selfie_image is now required for document verification (except …

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1822,13 +1822,14 @@ paths:
       summary: Document Verification
       operationId: documentVerification
       description: >
-        Extract identity details from a photo of a document using OCR, with
-        an optional face match against a selfie (still-image comparison
-        only — no liveness, no video, no blink/motion challenge). Fallback
-        for the number-lookup checks (Passport, Driver's License, NIN with
-        Face, VNIN, Voter's ID) while those are unavailable. Which
-        document_type values are valid depends on country — see the
-        Supported Documents table on this page.
+        Extract identity details from a photo of a document using OCR,
+        plus a required face match against a selfie (still-image
+        comparison only — no liveness, no video, no blink/motion
+        challenge) for every document_type except cac_certificate and
+        utility_bill. Fallback for the number-lookup checks (Passport,
+        Driver's License, NIN with Face, VNIN, Voter's ID) while those
+        are unavailable. Which document_type values are valid depends
+        on country — see the Supported Documents table on this page.
       requestBody:
         required: true
         content:
@@ -1876,11 +1877,11 @@ paths:
                   format: binary
                   description: >
                     A selfie to compare against the face extracted from the
-                    document. JPG or PNG, max 5MB. Optional — omit for
-                    OCR-only extraction. Still-image comparison only, not
-                    liveness. Ignored (face_match.attempted: false) for
-                    document types that don't carry a face photo
-                    (cac_certificate, utility_bill).
+                    document. JPG or PNG, max 5MB. Required for every
+                    document_type except cac_certificate and utility_bill,
+                    which never carry a face photo and reject the request
+                    with 400 if selfie_image is missing for any other type.
+                    Still-image comparison only, not liveness.
       responses:
         "200":
           description: Document details extracted successfully

--- a/v3/kyc/document_verification/canada/Passport.mdx
+++ b/v3/kyc/document_verification/canada/Passport.mdx
@@ -5,14 +5,14 @@ description: "Extract identity details from a Canadian passport using OCR."
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a customer's Canadian passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction, with an optional face match against a selfie — no liveness check (no video, no blink/motion challenge).
+Verify a customer's Canadian passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
 
 <Note>
   Passport is single-sided — only `document_front` is needed.
 </Note>
 
 <Note>
-  Add `selfie_image` to compare the face extracted from the document against a selfie. This is a still-image comparison (not liveness) — omit it for OCR-only extraction.
+  `selfie_image` is required — the face extracted from the document is compared against it. This is a still-image comparison (not liveness).
 </Note>
 
 ## Endpoint
@@ -37,7 +37,7 @@ POST /api/onboarding/document_verification
 | `document_type` | string | Yes | `passport` |
 | `country` | string | Yes | `canada` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
-| `selfie_image` | file | No | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
+| `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
 ### Example
 
@@ -56,7 +56,7 @@ const formData = new FormData();
 formData.append("document_type", "passport");
 formData.append("country", "canada");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
-formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg")); // optional
+formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
   "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
@@ -78,7 +78,7 @@ response = requests.post(
     data={"document_type": "passport", "country": "canada"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
-        "selfie_image": open("/path/to/selfie.jpg", "rb"),  # optional
+        "selfie_image": open("/path/to/selfie.jpg", "rb"),
     },
 )
 data = response.json()
@@ -104,7 +104,7 @@ data = response.json()
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
 | `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, `nin` (if embedded), and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
-| `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
+| `data.face_match` | object | Result of comparing the document's face against `selfie_image` — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
 | `data.face_match.confidence_percentage` | number | Match confidence, 0–100 |
@@ -144,7 +144,7 @@ data = response.json()
 ```
 
 <Note>
-  **Face Match Notes** — `face_match` is omitted entirely if `selfie_image` wasn't supplied. If the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
+  **Face Match Notes** — if the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
 </Note>
 
 ### 400 Bad Request

--- a/v3/kyc/document_verification/cote_d_ivoire/Passport.mdx
+++ b/v3/kyc/document_verification/cote_d_ivoire/Passport.mdx
@@ -5,14 +5,14 @@ description: "Extract identity details from a Côte d'Ivoire passport using OCR.
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a customer's Côte d'Ivoire passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction, with an optional face match against a selfie — no liveness check (no video, no blink/motion challenge).
+Verify a customer's Côte d'Ivoire passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
 
 <Note>
   Passport is single-sided — only `document_front` is needed.
 </Note>
 
 <Note>
-  Add `selfie_image` to compare the face extracted from the document against a selfie. This is a still-image comparison (not liveness) — omit it for OCR-only extraction.
+  `selfie_image` is required — the face extracted from the document is compared against it. This is a still-image comparison (not liveness).
 </Note>
 
 ## Endpoint
@@ -37,7 +37,7 @@ POST /api/onboarding/document_verification
 | `document_type` | string | Yes | `passport` |
 | `country` | string | Yes | `cote d'ivoire` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
-| `selfie_image` | file | No | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
+| `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
 ### Example
 
@@ -56,7 +56,7 @@ const formData = new FormData();
 formData.append("document_type", "passport");
 formData.append("country", "cote d'ivoire");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
-formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg")); // optional
+formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
   "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
@@ -78,7 +78,7 @@ response = requests.post(
     data={"document_type": "passport", "country": "cote d'ivoire"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
-        "selfie_image": open("/path/to/selfie.jpg", "rb"),  # optional
+        "selfie_image": open("/path/to/selfie.jpg", "rb"),
     },
 )
 data = response.json()
@@ -104,7 +104,7 @@ data = response.json()
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
 | `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, `nin` (if embedded), and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
-| `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
+| `data.face_match` | object | Result of comparing the document's face against `selfie_image` — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
 | `data.face_match.confidence_percentage` | number | Match confidence, 0–100 |
@@ -144,7 +144,7 @@ data = response.json()
 ```
 
 <Note>
-  **Face Match Notes** — `face_match` is omitted entirely if `selfie_image` wasn't supplied. If the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
+  **Face Match Notes** — if the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
 </Note>
 
 ### 400 Bad Request

--- a/v3/kyc/document_verification/ghana/Passport.mdx
+++ b/v3/kyc/document_verification/ghana/Passport.mdx
@@ -5,14 +5,14 @@ description: "Extract identity details from a Ghanaian passport using OCR."
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a customer's Ghanaian passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction, with an optional face match against a selfie — no liveness check (no video, no blink/motion challenge).
+Verify a customer's Ghanaian passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
 
 <Note>
   Passport is single-sided — only `document_front` is needed.
 </Note>
 
 <Note>
-  Add `selfie_image` to compare the face extracted from the document against a selfie. This is a still-image comparison (not liveness) — omit it for OCR-only extraction.
+  `selfie_image` is required — the face extracted from the document is compared against it. This is a still-image comparison (not liveness).
 </Note>
 
 ## Endpoint
@@ -37,7 +37,7 @@ POST /api/onboarding/document_verification
 | `document_type` | string | Yes | `passport` |
 | `country` | string | Yes | `ghana` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
-| `selfie_image` | file | No | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
+| `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
 ### Example
 
@@ -56,7 +56,7 @@ const formData = new FormData();
 formData.append("document_type", "passport");
 formData.append("country", "ghana");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
-formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg")); // optional
+formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
   "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
@@ -78,7 +78,7 @@ response = requests.post(
     data={"document_type": "passport", "country": "ghana"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
-        "selfie_image": open("/path/to/selfie.jpg", "rb"),  # optional
+        "selfie_image": open("/path/to/selfie.jpg", "rb"),
     },
 )
 data = response.json()
@@ -104,7 +104,7 @@ data = response.json()
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
 | `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, `nin` (if embedded), and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
-| `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
+| `data.face_match` | object | Result of comparing the document's face against `selfie_image` — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
 | `data.face_match.confidence_percentage` | number | Match confidence, 0–100 |
@@ -144,7 +144,7 @@ data = response.json()
 ```
 
 <Note>
-  **Face Match Notes** — `face_match` is omitted entirely if `selfie_image` wasn't supplied. If the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
+  **Face Match Notes** — if the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
 </Note>
 
 ### 400 Bad Request

--- a/v3/kyc/document_verification/kenya/Kenya_ID.mdx
+++ b/v3/kyc/document_verification/kenya/Kenya_ID.mdx
@@ -5,14 +5,14 @@ description: "Extract identity details from a Kenyan national ID card using OCR.
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a customer's Kenyan national ID card by uploading a photo — no manual ID entry required. OCR extraction, with an optional face match against a selfie — no liveness check (no video, no blink/motion challenge).
+Verify a customer's Kenyan national ID card by uploading a photo — no manual ID entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
 
 <Note>
   This is a two-sided document — supply both `document_front` and `document_back` for the most complete extraction. Kenya has two ID card generations in circulation: the older laminated design and the newer "Maisha Card." Fields specific to the Maisha Card (`serial_number`, `place_of_issue`, expiry date) will come back empty on an older card — that's expected, not an error.
 </Note>
 
 <Note>
-  Add `selfie_image` to compare the face extracted from the document against a selfie. This is a still-image comparison (not liveness) — omit it for OCR-only extraction.
+  `selfie_image` is required — the face extracted from the document is compared against it. This is a still-image comparison (not liveness).
 </Note>
 
 ## Endpoint
@@ -38,7 +38,7 @@ POST /api/onboarding/document_verification
 | `country` | string | Yes | `kenya` |
 | `document_front` | file | Yes | Front of the ID card. JPG or PNG, max 5MB |
 | `document_back` | file | No | Back of the ID card. JPG or PNG, max 5MB |
-| `selfie_image` | file | No | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
+| `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
 ### Example
 
@@ -59,7 +59,7 @@ formData.append("document_type", "kenya_id");
 formData.append("country", "kenya");
 formData.append("document_front", fs.createReadStream("/path/to/id_front.jpg"));
 formData.append("document_back", fs.createReadStream("/path/to/id_back.jpg"));
-formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg")); // optional
+formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
   "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
@@ -82,7 +82,7 @@ response = requests.post(
     files={
         "document_front": open("/path/to/id_front.jpg", "rb"),
         "document_back": open("/path/to/id_back.jpg", "rb"),
-        "selfie_image": open("/path/to/selfie.jpg", "rb"),  # optional
+        "selfie_image": open("/path/to/selfie.jpg", "rb"),
     },
 )
 data = response.json()
@@ -109,7 +109,7 @@ data = response.json()
 | `data.serial_number` | string | Separate 9-digit card serial number — only present on third-generation "Maisha Card" IDs |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
 | `data.extra_fields` | object | Other fields printed on the card — see below |
-| `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
+| `data.face_match` | object | Result of comparing the document's face against `selfie_image` — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
 | `data.face_match.confidence_percentage` | number | Match confidence, 0–100 |
@@ -159,7 +159,7 @@ data = response.json()
 </Note>
 
 <Note>
-  **Face Match Notes** — `face_match` is omitted entirely if `selfie_image` wasn't supplied. If the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
+  **Face Match Notes** — if the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
 </Note>
 
 ### 400 Bad Request

--- a/v3/kyc/document_verification/kenya/Passport.mdx
+++ b/v3/kyc/document_verification/kenya/Passport.mdx
@@ -5,14 +5,14 @@ description: "Extract identity details from a Kenyan passport using OCR."
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a customer's Kenyan passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction, with an optional face match against a selfie — no liveness check (no video, no blink/motion challenge).
+Verify a customer's Kenyan passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
 
 <Note>
   Passport is single-sided — only `document_front` is needed.
 </Note>
 
 <Note>
-  Add `selfie_image` to compare the face extracted from the document against a selfie. This is a still-image comparison (not liveness) — omit it for OCR-only extraction.
+  `selfie_image` is required — the face extracted from the document is compared against it. This is a still-image comparison (not liveness).
 </Note>
 
 ## Endpoint
@@ -37,7 +37,7 @@ POST /api/onboarding/document_verification
 | `document_type` | string | Yes | `passport` |
 | `country` | string | Yes | `kenya` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
-| `selfie_image` | file | No | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
+| `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
 ### Example
 
@@ -56,7 +56,7 @@ const formData = new FormData();
 formData.append("document_type", "passport");
 formData.append("country", "kenya");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
-formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg")); // optional
+formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
   "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
@@ -78,7 +78,7 @@ response = requests.post(
     data={"document_type": "passport", "country": "kenya"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
-        "selfie_image": open("/path/to/selfie.jpg", "rb"),  # optional
+        "selfie_image": open("/path/to/selfie.jpg", "rb"),
     },
 )
 data = response.json()
@@ -104,7 +104,7 @@ data = response.json()
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
 | `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, `nin` (if embedded), and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
-| `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
+| `data.face_match` | object | Result of comparing the document's face against `selfie_image` — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
 | `data.face_match.confidence_percentage` | number | Match confidence, 0–100 |
@@ -144,7 +144,7 @@ data = response.json()
 ```
 
 <Note>
-  **Face Match Notes** — `face_match` is omitted entirely if `selfie_image` wasn't supplied. If the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
+  **Face Match Notes** — if the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
 </Note>
 
 ### 400 Bad Request

--- a/v3/kyc/document_verification/nigeria/Drivers_License.mdx
+++ b/v3/kyc/document_verification/nigeria/Drivers_License.mdx
@@ -5,14 +5,14 @@ description: "Extract identity details from a Nigerian driver's license using OC
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a customer's Nigerian driver's license by uploading a photo — no manual license number entry required. OCR extraction, with an optional face match against a selfie — no liveness check (no video, no blink/motion challenge).
+Verify a customer's Nigerian driver's license by uploading a photo — no manual license number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
 
 <Note>
   This is a two-sided document — supply both `document_front` and `document_back` for the most complete extraction.
 </Note>
 
 <Note>
-  Add `selfie_image` to compare the face extracted from the document against a selfie. This is a still-image comparison (not liveness) — omit it for OCR-only extraction.
+  `selfie_image` is required — the face extracted from the document is compared against it. This is a still-image comparison (not liveness).
 </Note>
 
 ## Endpoint
@@ -38,7 +38,7 @@ POST /api/onboarding/document_verification
 | `country` | string | Yes | `nigeria` |
 | `document_front` | file | Yes | Front of the driver's license. JPG or PNG, max 5MB |
 | `document_back` | file | No | Back of the driver's license. JPG or PNG, max 5MB |
-| `selfie_image` | file | No | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
+| `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
 ### Example
 
@@ -59,7 +59,7 @@ formData.append("document_type", "drivers_license");
 formData.append("country", "nigeria");
 formData.append("document_front", fs.createReadStream("/path/to/license_front.jpg"));
 formData.append("document_back", fs.createReadStream("/path/to/license_back.jpg"));
-formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg")); // optional
+formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
   "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
@@ -82,7 +82,7 @@ response = requests.post(
     files={
         "document_front": open("/path/to/license_front.jpg", "rb"),
         "document_back": open("/path/to/license_back.jpg", "rb"),
-        "selfie_image": open("/path/to/selfie.jpg", "rb"),  # optional
+        "selfie_image": open("/path/to/selfie.jpg", "rb"),
     },
 )
 data = response.json()
@@ -107,7 +107,7 @@ data = response.json()
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
 | `data.extra_fields` | object | Every other field the license printed — see below |
-| `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
+| `data.face_match` | object | Result of comparing the document's face against `selfie_image` — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
 | `data.face_match.confidence_percentage` | number | Match confidence, 0–100 |
@@ -162,7 +162,7 @@ data = response.json()
 </Note>
 
 <Note>
-  **Face Match Notes** — `face_match` is omitted entirely if `selfie_image` wasn't supplied. If the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
+  **Face Match Notes** — if the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
 </Note>
 
 ### 400 Bad Request

--- a/v3/kyc/document_verification/nigeria/National_ID.mdx
+++ b/v3/kyc/document_verification/nigeria/National_ID.mdx
@@ -5,14 +5,14 @@ description: "Extract identity details from a Nigerian NIN slip or card using OC
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a customer's Nigerian National Identification Number slip or card by uploading a photo — no manual NIN entry required. OCR extraction, with an optional face match against a selfie — no liveness check (no video, no blink/motion challenge).
+Verify a customer's Nigerian National Identification Number slip or card by uploading a photo — no manual NIN entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
 
 <Note>
   This is a two-sided document — supply both `document_front` and `document_back` for the most complete extraction.
 </Note>
 
 <Note>
-  Add `selfie_image` to compare the face extracted from the document against a selfie. This is a still-image comparison (not liveness) — omit it for OCR-only extraction.
+  `selfie_image` is required — the face extracted from the document is compared against it. This is a still-image comparison (not liveness).
 </Note>
 
 ## Endpoint
@@ -38,7 +38,7 @@ POST /api/onboarding/document_verification
 | `country` | string | Yes | `nigeria` |
 | `document_front` | file | Yes | Front of the NIN slip/card. JPG or PNG, max 5MB |
 | `document_back` | file | No | Back of the NIN card. JPG or PNG, max 5MB |
-| `selfie_image` | file | No | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
+| `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
 ### Example
 
@@ -59,7 +59,7 @@ formData.append("document_type", "national_id");
 formData.append("country", "nigeria");
 formData.append("document_front", fs.createReadStream("/path/to/nin_front.jpg"));
 formData.append("document_back", fs.createReadStream("/path/to/nin_back.jpg"));
-formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg")); // optional
+formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
   "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
@@ -82,7 +82,7 @@ response = requests.post(
     files={
         "document_front": open("/path/to/nin_front.jpg", "rb"),
         "document_back": open("/path/to/nin_back.jpg", "rb"),
-        "selfie_image": open("/path/to/selfie.jpg", "rb"),  # optional
+        "selfie_image": open("/path/to/selfie.jpg", "rb"),
     },
 )
 data = response.json()
@@ -105,7 +105,7 @@ data = response.json()
 | `data.document_type` | string | `"national_id"` |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
 | `data.extra_fields` | object | Present if the card is the older two-sided format — see below |
-| `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
+| `data.face_match` | object | Result of comparing the document's face against `selfie_image` — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
 | `data.face_match.confidence_percentage` | number | Match confidence, 0–100 |
@@ -142,7 +142,7 @@ data = response.json()
 </Note>
 
 <Note>
-  **Face Match Notes** — `face_match` is omitted entirely if `selfie_image` wasn't supplied. If it was supplied but the document type doesn't carry a face, or the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
+  **Face Match Notes** — if the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
 </Note>
 
 ### 400 Bad Request

--- a/v3/kyc/document_verification/nigeria/Passport.mdx
+++ b/v3/kyc/document_verification/nigeria/Passport.mdx
@@ -5,14 +5,14 @@ description: "Extract identity details from a Nigerian international passport us
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a customer's Nigerian international passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction, with an optional face match against a selfie — no liveness check (no video, no blink/motion challenge).
+Verify a customer's Nigerian international passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
 
 <Note>
   Passport is single-sided — only `document_front` is needed.
 </Note>
 
 <Note>
-  Add `selfie_image` to compare the face extracted from the document against a selfie. This is a still-image comparison (not liveness) — omit it for OCR-only extraction.
+  `selfie_image` is required — the face extracted from the document is compared against it. This is a still-image comparison (not liveness).
 </Note>
 
 ## Endpoint
@@ -37,7 +37,7 @@ POST /api/onboarding/document_verification
 | `document_type` | string | Yes | `passport` |
 | `country` | string | Yes | `nigeria` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
-| `selfie_image` | file | No | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
+| `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
 ### Example
 
@@ -56,7 +56,7 @@ const formData = new FormData();
 formData.append("document_type", "passport");
 formData.append("country", "nigeria");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
-formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg")); // optional
+formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
   "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
@@ -78,7 +78,7 @@ response = requests.post(
     data={"document_type": "passport", "country": "nigeria"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
-        "selfie_image": open("/path/to/selfie.jpg", "rb"),  # optional
+        "selfie_image": open("/path/to/selfie.jpg", "rb"),
     },
 )
 data = response.json()
@@ -104,7 +104,7 @@ data = response.json()
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
 | `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, `nin` (if embedded), and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
-| `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
+| `data.face_match` | object | Result of comparing the document's face against `selfie_image` — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
 | `data.face_match.confidence_percentage` | number | Match confidence, 0–100 |
@@ -144,7 +144,7 @@ data = response.json()
 ```
 
 <Note>
-  **Face Match Notes** — `face_match` is omitted entirely if `selfie_image` wasn't supplied. If the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
+  **Face Match Notes** — if the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
 </Note>
 
 ### 400 Bad Request

--- a/v3/kyc/document_verification/nigeria/Voters_Card.mdx
+++ b/v3/kyc/document_verification/nigeria/Voters_Card.mdx
@@ -5,14 +5,14 @@ description: "Extract identity details from a Nigerian Permanent Voter's Card (P
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a customer's Nigerian Permanent Voter's Card (PVC) by uploading a photo — no manual voter ID entry required. OCR extraction, with an optional face match against a selfie — no liveness check (no video, no blink/motion challenge).
+Verify a customer's Nigerian Permanent Voter's Card (PVC) by uploading a photo — no manual voter ID entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
 
 <Note>
   Only `document_front` is needed for this document.
 </Note>
 
 <Note>
-  Add `selfie_image` to compare the face extracted from the document against a selfie. This is a still-image comparison (not liveness) — omit it for OCR-only extraction.
+  `selfie_image` is required — the face extracted from the document is compared against it. This is a still-image comparison (not liveness).
 </Note>
 
 ## Endpoint
@@ -37,7 +37,7 @@ POST /api/onboarding/document_verification
 | `document_type` | string | Yes | `voters_card` |
 | `country` | string | Yes | `nigeria` |
 | `document_front` | file | Yes | Photo of the PVC. JPG or PNG, max 5MB |
-| `selfie_image` | file | No | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
+| `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
 ### Example
 
@@ -56,7 +56,7 @@ const formData = new FormData();
 formData.append("document_type", "voters_card");
 formData.append("country", "nigeria");
 formData.append("document_front", fs.createReadStream("/path/to/pvc.jpg"));
-formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg")); // optional
+formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
   "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
@@ -78,7 +78,7 @@ response = requests.post(
     data={"document_type": "voters_card", "country": "nigeria"},
     files={
         "document_front": open("/path/to/pvc.jpg", "rb"),
-        "selfie_image": open("/path/to/selfie.jpg", "rb"),  # optional
+        "selfie_image": open("/path/to/selfie.jpg", "rb"),
     },
 )
 data = response.json()
@@ -103,7 +103,7 @@ data = response.json()
 | `data.document_type` | string | `"voters_card"` |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
 | `data.extra_fields` | object | Other fields printed on the card — see below |
-| `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
+| `data.face_match` | object | Result of comparing the document's face against `selfie_image` — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
 | `data.face_match.confidence_percentage` | number | Match confidence, 0–100 |
@@ -150,7 +150,7 @@ data = response.json()
 </Note>
 
 <Note>
-  **Face Match Notes** — `face_match` is omitted entirely if `selfie_image` wasn't supplied. If the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
+  **Face Match Notes** — if the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
 </Note>
 
 ### 400 Bad Request

--- a/v3/kyc/document_verification/usa/Passport.mdx
+++ b/v3/kyc/document_verification/usa/Passport.mdx
@@ -5,14 +5,14 @@ description: "Extract identity details from a United States passport using OCR."
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a customer's United States passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction, with an optional face match against a selfie — no liveness check (no video, no blink/motion challenge).
+Verify a customer's United States passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
 
 <Note>
   Passport is single-sided — only `document_front` is needed.
 </Note>
 
 <Note>
-  Add `selfie_image` to compare the face extracted from the document against a selfie. This is a still-image comparison (not liveness) — omit it for OCR-only extraction.
+  `selfie_image` is required — the face extracted from the document is compared against it. This is a still-image comparison (not liveness).
 </Note>
 
 ## Endpoint
@@ -37,7 +37,7 @@ POST /api/onboarding/document_verification
 | `document_type` | string | Yes | `passport` |
 | `country` | string | Yes | `usa` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
-| `selfie_image` | file | No | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
+| `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
 ### Example
 
@@ -56,7 +56,7 @@ const formData = new FormData();
 formData.append("document_type", "passport");
 formData.append("country", "usa");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
-formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg")); // optional
+formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
   "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
@@ -78,7 +78,7 @@ response = requests.post(
     data={"document_type": "passport", "country": "usa"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
-        "selfie_image": open("/path/to/selfie.jpg", "rb"),  # optional
+        "selfie_image": open("/path/to/selfie.jpg", "rb"),
     },
 )
 data = response.json()
@@ -104,7 +104,7 @@ data = response.json()
 | `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
 | `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, `nin` (if embedded), and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
-| `data.face_match` | object | Present only when `selfie_image` was supplied — see below |
+| `data.face_match` | object | Result of comparing the document's face against `selfie_image` — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
 | `data.face_match.confidence_percentage` | number | Match confidence, 0–100 |
@@ -144,7 +144,7 @@ data = response.json()
 ```
 
 <Note>
-  **Face Match Notes** — `face_match` is omitted entirely if `selfie_image` wasn't supplied. If the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
+  **Face Match Notes** — if the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
 </Note>
 
 ### 400 Bad Request


### PR DESCRIPTION
…CAC/utility bill)

Backend now rejects the request with 400 if selfie_image is missing for any document_type that carries a face photo (previously fully optional, so face match silently never ran unless the caller happened to include it). Updated across all 10 affected pages (every type/country except cac_certificate and utility_bill, which never carry a face and are unaffected) plus the OpenAPI spec that drives the interactive playground:

- Body Parameters table: selfie_image Required column No -> Yes
- Intro paragraph and Note: "optional face match" -> "required face match"
- Code examples: dropped the now-inaccurate "// optional" / "# optional" comments on selfie_image
- face_match field description and Face Match Notes callout: dropped the "omitted if selfie_image wasn't supplied" framing, since it's now always supplied for these types