### PR TITLE
docs: hide CAC Certificate and Utility Bill from Nigeria document ver…

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -157,9 +157,7 @@
                               "v3/kyc/document_verification/nigeria/National_ID",
                               "v3/kyc/document_verification/nigeria/Passport",
                               "v3/kyc/document_verification/nigeria/Drivers_License",
-                              "v3/kyc/document_verification/nigeria/Voters_Card",
-                              "v3/kyc/document_verification/nigeria/CAC_Certificate",
-                              "v3/kyc/document_verification/nigeria/Utility_Bill"
+                              "v3/kyc/document_verification/nigeria/Voters_Card"
                             ]
                           },
                           {


### PR DESCRIPTION
…ification nav

Removed from docs.json's navigation only — the .mdx pages themselves are untouched on disk, so this is easily reversible by re-adding the two entries back to the Nigeria group's pages array.