### PR TITLE
docs: remove id_type from sample responses — duplicated document_type

### DIFF
--- a/v3/kyc/document_verification/canada/Passport.mdx
+++ b/v3/kyc/document_verification/canada/Passport.mdx
@@ -123,7 +123,6 @@ data = response.json()
     "gender": "M",
     "nationality": "CANADIAN",
     "id_number": "GA123456",
-    "id_type": "passport",
     "document_type": "passport",
     "expiry_date": "2027-09-30",
     "is_expired": false,

--- a/v3/kyc/document_verification/cote_d_ivoire/Passport.mdx
+++ b/v3/kyc/document_verification/cote_d_ivoire/Passport.mdx
@@ -123,7 +123,6 @@ data = response.json()
     "gender": "M",
     "nationality": "IVORIAN",
     "id_number": "CI1234567",
-    "id_type": "passport",
     "document_type": "passport",
     "expiry_date": "2028-03-17",
     "is_expired": false,

--- a/v3/kyc/document_verification/ghana/Passport.mdx
+++ b/v3/kyc/document_verification/ghana/Passport.mdx
@@ -123,7 +123,6 @@ data = response.json()
     "gender": "M",
     "nationality": "GHANAIAN",
     "id_number": "G1234567",
-    "id_type": "passport",
     "document_type": "passport",
     "expiry_date": "2028-02-20",
     "is_expired": false,

--- a/v3/kyc/document_verification/kenya/Kenya_ID.mdx
+++ b/v3/kyc/document_verification/kenya/Kenya_ID.mdx
@@ -126,7 +126,6 @@ data = response.json()
     "full_name": "KAMAU WANJIRU",
     "date_of_birth": "1995-03-10",
     "id_number": "34567890",
-    "id_type": "kenya_id",
     "document_type": "kenya_id",
     "issue_date": "2019-05-14",
     "place_of_issue": "NAIROBI",

--- a/v3/kyc/document_verification/kenya/Passport.mdx
+++ b/v3/kyc/document_verification/kenya/Passport.mdx
@@ -123,7 +123,6 @@ data = response.json()
     "gender": "F",
     "nationality": "KENYAN",
     "id_number": "K1234567",
-    "id_type": "passport",
     "document_type": "passport",
     "expiry_date": "2029-08-15",
     "is_expired": false,

--- a/v3/kyc/document_verification/nigeria/CAC_Certificate.mdx
+++ b/v3/kyc/document_verification/nigeria/CAC_Certificate.mdx
@@ -101,7 +101,6 @@ data = response.json()
     "full_name": "FISAYOMI KAYODE NIG LTD",
     "address": "12 CORPORATE DRIVE, VICTORIA ISLAND, LAGOS",
     "id_number": "RC012345",
-    "id_type": "cac_certificate",
     "document_type": "cac_certificate",
     "extra_fields": {
       "business_type": "LIMITED LIABILITY COMPANY",

--- a/v3/kyc/document_verification/nigeria/Drivers_License.mdx
+++ b/v3/kyc/document_verification/nigeria/Drivers_License.mdx
@@ -126,7 +126,6 @@ data = response.json()
     "gender": "M",
     "address": "STATE HOUSE",
     "id_number": "JTC0977DD",
-    "id_type": "drivers_license",
     "document_type": "drivers_license",
     "expiry_date": "2030-11-20",
     "is_expired": false,

--- a/v3/kyc/document_verification/nigeria/National_ID.mdx
+++ b/v3/kyc/document_verification/nigeria/National_ID.mdx
@@ -123,7 +123,6 @@ data = response.json()
     "date_of_birth": "2002-02-16",
     "gender": "M",
     "id_number": "12345678901",
-    "id_type": "national_id",
     "document_type": "national_id",
     "photo": "/9j/4AAQSkZJRgABAQAAAQABAAD...",
     "face_match": {

--- a/v3/kyc/document_verification/nigeria/Passport.mdx
+++ b/v3/kyc/document_verification/nigeria/Passport.mdx
@@ -123,7 +123,6 @@ data = response.json()
     "gender": "M",
     "nationality": "NIGERIAN",
     "id_number": "A12345678",
-    "id_type": "passport",
     "document_type": "passport",
     "expiry_date": "2030-01-01",
     "is_expired": false,

--- a/v3/kyc/document_verification/nigeria/Utility_Bill.mdx
+++ b/v3/kyc/document_verification/nigeria/Utility_Bill.mdx
@@ -101,7 +101,6 @@ data = response.json()
     "full_name": "AYODELE TUNDE",
     "address": "12 Adeola Odeku Street, Victoria Island, Lagos",
     "id_number": "1234567890",
-    "id_type": "utility_bill",
     "document_type": "utility_bill",
     "extra_fields": {
       "issuer_name": "IKEJA ELECTRIC",

--- a/v3/kyc/document_verification/nigeria/Voters_Card.mdx
+++ b/v3/kyc/document_verification/nigeria/Voters_Card.mdx
@@ -123,7 +123,6 @@ data = response.json()
     "address": "12 ALLEN AVENUE, IKEJA, LAGOS",
     "id_number": "90F5A1B2C3D4E5F6",
     "serial_number": "SN00123456",
-    "id_type": "voters_card",
     "document_type": "voters_card",
     "photo": "/9j/4AAQSkZJRgABAQAAAQABAAD...",
     "extra_fields": {

--- a/v3/kyc/document_verification/usa/Passport.mdx
+++ b/v3/kyc/document_verification/usa/Passport.mdx
@@ -123,7 +123,6 @@ data = response.json()
     "gender": "M",
     "nationality": "USA",
     "id_number": "543219876",
-    "id_type": "passport",
     "document_type": "passport",
     "expiry_date": "2029-06-12",
     "is_expired": false,


### PR DESCRIPTION
Backend fix (adhere-backend fix/document-verification-full-name-and- duplicate-fields): id_type and document_type were always set to the identical value for every document type, so every sample response here showed the same string twice under two field names. document_type was already the only one actually documented in the field tables — id_type was only ever in the sample JSON, never listed as a real field, so removing it here just brings the samples in line with what was already documented.