### PR TITLE
docs: add Kenya Driver's License, Ghana Passport, Cote d'Ivoire and South Africa National ID

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -136,14 +136,28 @@
                               "v3/kyc/kenya/business_registration",
                               "v3/kyc/kenya/alien_ID",
                               "v3/kyc/kenya/kra_pin",
-                              "v3/kyc/kenya/Passport_Verification"
+                              "v3/kyc/kenya/Passport_Verification",
+                              "v3/kyc/kenya/Drivers_License"
                             ]
                           },
                           {
                             "group": "Ghana",
                             "pages": [
                               "v3/kyc/ghana/ID_Card",
-                              "v3/kyc/ghana/ID_Card_with_face"
+                              "v3/kyc/ghana/ID_Card_with_face",
+                              "v3/kyc/ghana/International_Passport"
+                            ]
+                          },
+                          {
+                            "group": "Cote d'Ivoire",
+                            "pages": [
+                              "v3/kyc/cote_d_ivoire/National_ID"
+                            ]
+                          },
+                          {
+                            "group": "South Africa",
+                            "pages": [
+                              "v3/kyc/south_africa/National_ID"
                             ]
                           }
                         ]

--- a/v3/kyc/cote_d_ivoire/National_ID.mdx
+++ b/v3/kyc/cote_d_ivoire/National_ID.mdx
@@ -1,0 +1,120 @@
+---
+title: "National ID"
+sidebarTitle: "National ID"
+description: "Verify a customer's identity using their Côte d'Ivoire national ID number (NNI)."
+openapi: "POST /api/onboarding/cote_divoire_kyc/national_id/"
+---
+
+The Côte d'Ivoire National ID endpoint validates a national ID number (NNI) and returns the associated personal details from the national registry.
+
+## Endpoint
+
+```
+POST /api/onboarding/cote_divoire_kyc/national_id/
+```
+
+## Request
+
+### Headers
+
+| Header | Value | Required |
+|--------|-------|----------|
+| `x-access-token` | Your API secret key | Yes |
+| `Content-Type` | `application/json` | Yes |
+
+### Body Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `national_id` | string | Yes | The customer's Côte d'Ivoire national ID number (NNI) |
+
+### Example
+
+<CodeGroup>
+```bash cURL
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/cote_divoire_kyc/national_id/" \
+  -H "x-access-token: YOUR_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"national_id": "11715641589"}'
+```
+
+```javascript Node.js
+const response = await fetch(
+  "https://adhere-api.smartcomply.com/api/onboarding/cote_divoire_kyc/national_id/",
+  {
+    method: "POST",
+    headers: {
+      "x-access-token": "YOUR_SECRET_KEY",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ national_id: "11715641589" }),
+  }
+);
+const data = await response.json();
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://adhere-api.smartcomply.com/api/onboarding/cote_divoire_kyc/national_id/",
+    headers={
+        "x-access-token": "YOUR_SECRET_KEY",
+        "Content-Type": "application/json",
+    },
+    json={"national_id": "11715641589"},
+)
+data = response.json()
+```
+</CodeGroup>
+
+## Response
+
+### 200 OK
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.valid` | boolean | Whether the ID is valid |
+| `data.first_name` | string | Customer's first name |
+| `data.last_name` | string | Customer's last name |
+| `data.middle_name` | string | Middle name, if any |
+| `data.date_of_birth` | string | Date of birth |
+| `data.gender` | string | Gender |
+| `data.nationality` | string | Nationality |
+| `data.id_number` | string | National ID number |
+
+```json
+{
+  "status": "success",
+  "data": {
+    "valid": true,
+    "first_name": "JEAN",
+    "last_name": "KOUASSI",
+    "middle_name": "",
+    "date_of_birth": "1988-07-22",
+    "gender": "Male",
+    "nationality": "Ivorian",
+    "id_number": "11715641589"
+  },
+  "message": "National ID details retrieved successfully"
+}
+```
+
+### 400 Bad Request
+
+```json
+{
+  "status": "failed",
+  "data": [],
+  "message": "Sorry, your check cannot be processed at the moment. Please try again in a few minutes"
+}
+```
+
+### 401 Unauthorized
+
+```json
+{
+  "status": "failed",
+  "message": "Authentication credentials were not provided."
+}
+```

--- a/v3/kyc/ghana/International_Passport.mdx
+++ b/v3/kyc/ghana/International_Passport.mdx
@@ -1,0 +1,120 @@
+---
+title: "International Passport"
+sidebarTitle: "International Passport"
+description: "Verify a customer's identity using their Ghanaian international passport number."
+openapi: "POST /api/onboarding/ghana_kyc/international_passport/"
+---
+
+The Ghana International Passport endpoint validates a passport number and returns the associated personal details from the national registry.
+
+## Endpoint
+
+```
+POST /api/onboarding/ghana_kyc/international_passport/
+```
+
+## Request
+
+### Headers
+
+| Header | Value | Required |
+|--------|-------|----------|
+| `x-access-token` | Your API secret key | Yes |
+| `Content-Type` | `application/json` | Yes |
+
+### Body Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `passport_number` | string | Yes | The customer's Ghanaian passport number |
+
+### Example
+
+<CodeGroup>
+```bash cURL
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/ghana_kyc/international_passport/" \
+  -H "x-access-token: YOUR_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"passport_number": "G3759982"}'
+```
+
+```javascript Node.js
+const response = await fetch(
+  "https://adhere-api.smartcomply.com/api/onboarding/ghana_kyc/international_passport/",
+  {
+    method: "POST",
+    headers: {
+      "x-access-token": "YOUR_SECRET_KEY",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ passport_number: "G3759982" }),
+  }
+);
+const data = await response.json();
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://adhere-api.smartcomply.com/api/onboarding/ghana_kyc/international_passport/",
+    headers={
+        "x-access-token": "YOUR_SECRET_KEY",
+        "Content-Type": "application/json",
+    },
+    json={"passport_number": "G3759982"},
+)
+data = response.json()
+```
+</CodeGroup>
+
+## Response
+
+### 200 OK
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.valid` | boolean | Whether the passport is valid |
+| `data.first_name` | string | Customer's first name |
+| `data.last_name` | string | Customer's last name |
+| `data.middle_name` | string | Middle name, if any |
+| `data.date_of_birth` | string | Date of birth |
+| `data.gender` | string | Gender |
+| `data.nationality` | string | Nationality |
+| `data.id_number` | string | Passport number |
+
+```json
+{
+  "status": "success",
+  "data": {
+    "valid": true,
+    "first_name": "JOHN",
+    "last_name": "DOE",
+    "middle_name": "",
+    "date_of_birth": "1990-04-15",
+    "gender": "Male",
+    "nationality": "Ghanaian",
+    "id_number": "G3759982"
+  },
+  "message": "International Passport details retrieved successfully"
+}
+```
+
+### 400 Bad Request
+
+```json
+{
+  "status": "failed",
+  "data": [],
+  "message": "Sorry, your check cannot be processed at the moment. Please try again in a few minutes"
+}
+```
+
+### 401 Unauthorized
+
+```json
+{
+  "status": "failed",
+  "message": "Authentication credentials were not provided."
+}
+```

--- a/v3/kyc/kenya/Drivers_License.mdx
+++ b/v3/kyc/kenya/Drivers_License.mdx
@@ -1,0 +1,116 @@
+---
+title: "Driver's License"
+sidebarTitle: "Driver's License"
+description: "Verify a customer's identity using their Kenyan driver's license number."
+openapi: "POST /api/onboarding/kenya_kyc/drivers_license/"
+---
+
+The Kenya Driver's License endpoint validates a driver's license number and returns the associated personal details from the national registry.
+
+## Endpoint
+
+```
+POST /api/onboarding/kenya_kyc/drivers_license/
+```
+
+## Request
+
+### Headers
+
+| Header | Value | Required |
+|--------|-------|----------|
+| `x-access-token` | Your API secret key | Yes |
+| `Content-Type` | `application/json` | Yes |
+
+### Body Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `license_number` | string | Yes | The customer's Kenyan driver's license number |
+
+### Example
+
+<CodeGroup>
+```bash cURL
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/kenya_kyc/drivers_license/" \
+  -H "x-access-token: YOUR_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"license_number": "24478782"}'
+```
+
+```javascript Node.js
+const response = await fetch(
+  "https://adhere-api.smartcomply.com/api/onboarding/kenya_kyc/drivers_license/",
+  {
+    method: "POST",
+    headers: {
+      "x-access-token": "YOUR_SECRET_KEY",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ license_number: "24478782" }),
+  }
+);
+const data = await response.json();
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://adhere-api.smartcomply.com/api/onboarding/kenya_kyc/drivers_license/",
+    headers={
+        "x-access-token": "YOUR_SECRET_KEY",
+        "Content-Type": "application/json",
+    },
+    json={"license_number": "24478782"},
+)
+data = response.json()
+```
+</CodeGroup>
+
+## Response
+
+### 200 OK
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.valid` | boolean | Whether the license is valid |
+| `data.id_number` | string | Driver's license number |
+| `data.full_name` | string | Customer's full name |
+| `data.phone` | string | Registered phone number |
+| `data.email` | string | Registered email address |
+| `data.nationality` | string | Nationality |
+
+```json
+{
+  "status": "success",
+  "data": {
+    "valid": true,
+    "full_name": "CHARLOTTE SARAH KWENA",
+    "phone": "+254721583847",
+    "email": "kwenacharlotte@gmail.com",
+    "nationality": "KE",
+    "id_number": "24478782"
+  },
+  "message": "Driver's License details retrieved successfully"
+}
+```
+
+### 400 Bad Request
+
+```json
+{
+  "status": "failed",
+  "data": [],
+  "message": "Sorry, your check cannot be processed at the moment. Please try again in a few minutes"
+}
+```
+
+### 401 Unauthorized
+
+```json
+{
+  "status": "failed",
+  "message": "Authentication credentials were not provided."
+}
+```

--- a/v3/kyc/south_africa/National_ID.mdx
+++ b/v3/kyc/south_africa/National_ID.mdx
@@ -1,0 +1,118 @@
+---
+title: "National ID"
+sidebarTitle: "National ID"
+description: "Verify a customer's identity using their South African ID number (SAID)."
+openapi: "POST /api/onboarding/south_africa_kyc/national_id/"
+---
+
+The South Africa National ID endpoint validates a South African ID number (SAID) and returns the associated personal details from the national registry.
+
+## Endpoint
+
+```
+POST /api/onboarding/south_africa_kyc/national_id/
+```
+
+## Request
+
+### Headers
+
+| Header | Value | Required |
+|--------|-------|----------|
+| `x-access-token` | Your API secret key | Yes |
+| `Content-Type` | `application/json` | Yes |
+
+### Body Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `national_id` | string | Yes | The customer's South African ID number (SAID) |
+
+### Example
+
+<CodeGroup>
+```bash cURL
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/south_africa_kyc/national_id/" \
+  -H "x-access-token: YOUR_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"national_id": "0508225709080"}'
+```
+
+```javascript Node.js
+const response = await fetch(
+  "https://adhere-api.smartcomply.com/api/onboarding/south_africa_kyc/national_id/",
+  {
+    method: "POST",
+    headers: {
+      "x-access-token": "YOUR_SECRET_KEY",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ national_id: "0508225709080" }),
+  }
+);
+const data = await response.json();
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://adhere-api.smartcomply.com/api/onboarding/south_africa_kyc/national_id/",
+    headers={
+        "x-access-token": "YOUR_SECRET_KEY",
+        "Content-Type": "application/json",
+    },
+    json={"national_id": "0508225709080"},
+)
+data = response.json()
+```
+</CodeGroup>
+
+## Response
+
+### 200 OK
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.valid` | boolean | Whether the ID is valid |
+| `data.first_name` | string | Customer's first name |
+| `data.last_name` | string | Customer's last name |
+| `data.middle_name` | string | Middle name, if any |
+| `data.date_of_birth` | string | Date of birth |
+| `data.gender` | string | Gender |
+| `data.nationality` | string | Nationality |
+| `data.id_number` | string | South African ID number |
+
+```json
+{
+  "status": "success",
+  "data": {
+    "valid": true,
+    "first_name": "IRVEN",
+    "middle_name": "LONDILE",
+    "last_name": "RAMOLETA",
+    "nationality": "ZA",
+    "id_number": "0508225709080"
+  },
+  "message": "National ID details retrieved successfully"
+}
+```
+
+### 400 Bad Request
+
+```json
+{
+  "status": "failed",
+  "data": [],
+  "message": "Sorry, your check cannot be processed at the moment. Please try again in a few minutes"
+}
+```
+
+### 401 Unauthorized
+
+```json
+{
+  "status": "failed",
+  "message": "Authentication credentials were not provided."
+}
+```


### PR DESCRIPTION
Four IVS identity checks that were live and working in the API but had no documentation page: Kenya Driver's License, Ghana International Passport, Cote d'Ivoire National ID, and South Africa National ID (two entirely new country sections). All four confirmed working via live test calls before writing these pages.