### PR TITLE
docs: add UK passport document verification, update Kenya document-ty…pe-mismatch message

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -197,6 +197,10 @@
                           {
                             "group": "Cote d'Ivoire",
                             "pages": ["v3/kyc/document_verification/cote_d_ivoire/Passport"]
+                          },
+                          {
+                            "group": "UK",
+                            "pages": ["v3/kyc/document_verification/uk/Passport"]
                           }
                         ]
                       }

--- a/v3/kyc/document_verification/uk/Passport.mdx
+++ b/v3/kyc/document_verification/uk/Passport.mdx
@@ -1,18 +1,22 @@
 ---
-title: "Kenya National ID"
-sidebarTitle: "National ID"
-description: "Extract identity details from a Kenyan national ID card using OCR."
+title: "Passport"
+sidebarTitle: "Passport"
+description: "Extract identity details from a UK passport using OCR."
 openapi: "POST /api/onboarding/document_verification"
 ---
 
-Verify a customer's Kenyan national ID card by uploading a photo — no manual ID entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
+Verify a customer's UK passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
 
 <Note>
-  This is a two-sided document — supply both `document_front` and `document_back` for the most complete extraction. Kenya has two ID card generations in circulation: the older laminated design and the newer "Maisha Card." Fields specific to the Maisha Card (`serial_number`, `place_of_issue`, expiry date) will come back empty on an older card — that's expected, not an error.
+  Passport is single-sided — only `document_front` is needed.
 </Note>
 
 <Note>
   `selfie_image` is required — the face extracted from the document is compared against it. This is a still-image comparison (not liveness).
+</Note>
+
+<Note>
+  UK document verification currently supports passports only — national ID, driver's license, and other UK document types are not yet available.
 </Note>
 
 ## Endpoint
@@ -34,10 +38,9 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `kenya_id` |
-| `country` | string | Yes | `kenya` |
-| `document_front` | file | Yes | Front of the ID card. JPG or PNG, max 5MB |
-| `document_back` | file | No | Back of the ID card. JPG or PNG, max 5MB |
+| `document_type` | string | Yes | `passport` |
+| `country` | string | Yes | `uk` |
+| `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
 | `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
 ### Example
@@ -46,19 +49,17 @@ POST /api/onboarding/document_verification
 ```bash cURL
 curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=kenya_id" \
-  -F "country=kenya" \
-  -F "document_front=@/path/to/id_front.jpg" \
-  -F "document_back=@/path/to/id_back.jpg" \
+  -F "document_type=passport" \
+  -F "country=uk" \
+  -F "document_front=@/path/to/passport.jpg" \
   -F "selfie_image=@/path/to/selfie.jpg"
 ```
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "kenya_id");
-formData.append("country", "kenya");
-formData.append("document_front", fs.createReadStream("/path/to/id_front.jpg"));
-formData.append("document_back", fs.createReadStream("/path/to/id_back.jpg"));
+formData.append("document_type", "passport");
+formData.append("country", "uk");
+formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
 formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
@@ -78,10 +79,9 @@ import requests
 response = requests.post(
     "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "kenya_id", "country": "kenya"},
+    data={"document_type": "passport", "country": "uk"},
     files={
-        "document_front": open("/path/to/id_front.jpg", "rb"),
-        "document_back": open("/path/to/id_back.jpg", "rb"),
+        "document_front": open("/path/to/passport.jpg", "rb"),
         "selfie_image": open("/path/to/selfie.jpg", "rb"),
     },
 )
@@ -101,14 +101,13 @@ data = response.json()
 | `data.last_name` | string | Extracted last name |
 | `data.date_of_birth` | string | Date of birth in `YYYY-MM-DD` format |
 | `data.gender` | string | Extracted gender |
-| `data.id_number` | string | The ID number |
-| `data.document_type` | string | `"kenya_id"` |
-| `data.expiry_date` | string | Maisha Card expiry date — only present on third-generation cards |
-| `data.issue_date` | string | Date of issue |
-| `data.place_of_issue` | string | Only present on third-generation "Maisha Card" IDs |
-| `data.serial_number` | string | Separate 9-digit card serial number — only present on third-generation "Maisha Card" IDs |
+| `data.nationality` | string | Extracted nationality |
+| `data.id_number` | string | The passport number |
+| `data.document_type` | string | `"passport"` |
+| `data.expiry_date` | string | Passport expiry date |
+| `data.is_expired` | boolean | Whether `expiry_date` has already passed |
 | `data.photo` | string | Base64-encoded face photo extracted from the document |
-| `data.extra_fields` | object | Other fields printed on the card — see below |
+| `data.extra_fields` | object | Other fields OCR read from the data page — `place_of_birth`, `issuing_authority`, and `mrz_line1`/`mrz_line2` if the machine-readable zone was legible, exactly as printed |
 | `data.face_match` | object | Result of comparing the document's face against `selfie_image` — see below |
 | `data.face_match.attempted` | boolean | Whether a comparison was actually run |
 | `data.face_match.verified` | boolean \| null | `true`/`false` if the comparison ran; `null` if it couldn't (see Face Match Notes) |
@@ -121,26 +120,19 @@ data = response.json()
   "status": "success",
   "data": {
     "valid": true,
-    "first_name": "WANJIRU",
-    "last_name": "KAMAU",
-    "full_name": "KAMAU WANJIRU",
-    "date_of_birth": "1995-03-10",
-    "id_number": "34567890",
-    "document_type": "kenya_id",
-    "issue_date": "2019-05-14",
-    "place_of_issue": "NAIROBI",
-    "serial_number": "123456789",
+    "first_name": "JAMES",
+    "last_name": "SMITH",
+    "full_name": "SMITH JAMES",
+    "date_of_birth": "1988-07-22",
+    "gender": "M",
+    "nationality": "BRITISH",
+    "id_number": "533018723",
+    "document_type": "passport",
+    "expiry_date": "2029-04-15",
+    "is_expired": false,
     "photo": "/9j/4AAQSkZJRgABAQAAAQABAAD...",
     "extra_fields": {
-      "district_of_birth": "NAIROBI",
-      "district": "NAIROBI",
-      "division": "CENTRAL",
-      "location": "NAIROBI CENTRAL",
-      "sub_location": "CBD",
-      "barcode_number": "12345678",
-      "mrz_line1": "IDKEN3456789012<<<<<<<<<<<<<<<",
-      "mrz_line2": "9503109F2905147KEN<<<<<<<<<<<8",
-      "mrz_line3": "KAMAU<<WANJIRU<<<<<<<<<<<<<<<<"
+      "place_of_birth": "LONDON"
     },
     "face_match": {
       "attempted": true,
@@ -154,10 +146,6 @@ data = response.json()
 ```
 
 <Note>
-  **Extra Fields** — `extra_fields` carries whatever else the card printed beyond the fields listed above: `district_of_birth`, and — only when `document_back` was supplied — `district`, `division`, `location`, `sub_location`, `barcode_number`, and the three MRZ lines (`mrz_line1`/`mrz_line2`/`mrz_line3`, exactly as printed, including `<` fill characters — not decoded). Only fields actually present on the card are included.
-</Note>
-
-<Note>
   **Face Match Notes** — if the comparison service itself fails, `attempted` reflects whether a comparison was actually run and `verified` comes back `null` with a `reason` field explaining why — this is different from `verified: false`, which means the comparison ran and the faces didn't match. A face-match problem never blocks the underlying document data — the rest of `data` is still returned.
 </Note>
 
@@ -167,7 +155,7 @@ data = response.json()
 {
   "status": "failed",
   "data": [],
-  "message": "This document is not supported for the selected ID type — please upload the correct document."
+  "message": "ID photo is too blurry — please retake in good lighting with a steady hand"
 }
 ```
 


### PR DESCRIPTION
- New page: v3/kyc/document_verification/uk/Passport.mdx — UK is passport-only for document verification (no national_id/drivers_license support), following the same single-document-type pattern as Canada/USA/Ghana/Cote d'Ivoire's passport pages.
- docs.json: added the UK nav group under Document Verification.
- Kenya_ID.mdx: 400 example response updated to match the reworded document_type_mismatch error text ("This document is not supported for the selected ID type — please upload the correct document."), matching the backend's updated rejection messaging.

Backend support for UK (declared_countries="uk", passport only) shipped in adhere-backend PR fix/ivs-nigeria-passport-rename-and-dropdown-fixes.