### PR TITLE
docs: dedicated per-country document verification endpoints, fix playground defaults

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -50,6 +50,59 @@ components:
               message:
                 type: string
                 example: Authentication credentials were not provided.
+    DocumentVerificationSuccess:
+      description: Document details extracted successfully
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                example: "success"
+              data:
+                type: object
+                properties:
+                  valid: { type: boolean }
+                  first_name: { type: string }
+                  last_name: { type: string }
+                  full_name: { type: string }
+                  date_of_birth: { type: string }
+                  gender: { type: string }
+                  nationality: { type: string }
+                  address: { type: string }
+                  id_number: { type: string }
+                  serial_number: { type: string }
+                  id_type: { type: string }
+                  document_type: { type: string }
+                  expiry_date: { type: string }
+                  issue_date: { type: string }
+                  is_expired: { type: boolean }
+                  photo:
+                    type: string
+                    description: Base64-encoded face photo extracted from the document. Absent for document types with no face photo (cac_certificate, utility_bill).
+                  extra_fields:
+                    type: object
+                    description: Every other field OCR read from the document that doesn't have its own dedicated field above. Varies by document_type and country.
+                  face_match:
+                    type: object
+                    description: Present only when selfie_image was supplied.
+                    properties:
+                      attempted: { type: boolean }
+                      verified:
+                        type: boolean
+                        nullable: true
+                        description: "true/false if the comparison ran; null if it couldn't (see reason)."
+                      confidence_percentage: { type: number }
+                      selfie_image:
+                        type: string
+                        description: URL of the uploaded selfie.
+                      reason:
+                        type: string
+                        description: Present when verified is null — explains why the comparison couldn't run or complete.
+              message:
+                type: string
+                example: "Document details retrieved successfully"
 
 tags:
   - name: Nigeria KYC
@@ -1819,7 +1872,7 @@ paths:
   /api/onboarding/document_verification:
     post:
       tags: [Document Verification]
-      summary: Document Verification
+      summary: Document Verification (generic)
       operationId: documentVerification
       description: >
         Extract identity details from a photo of a document using OCR,
@@ -1829,7 +1882,15 @@ paths:
         utility_bill. Fallback for the number-lookup checks (Passport,
         Driver's License, NIN with Face, VNIN, Voter's ID) while those
         are unavailable. Which document_type values are valid depends
-        on country — see the Supported Documents table on this page.
+        on country.
+
+
+        A dedicated endpoint exists per country/document-type combination
+        (see the other Document Verification operations below) — prefer
+        those where possible, since document_type and country are baked
+        into the URL instead of the request body. This generic endpoint
+        still works unchanged for existing integrations that already pass
+        document_type/country explicitly.
       requestBody:
         required: true
         content:
@@ -1857,7 +1918,8 @@ paths:
                   example: "passport"
                 country:
                   type: string
-                  enum: [nigeria, kenya, ghana, canada, usa, "cote d'ivoire"]
+                  enum:
+                    [nigeria, kenya, ghana, canada, usa, "cote d'ivoire", uk]
                   description: Country the document was issued in.
                   example: "nigeria"
                 document_front:
@@ -1870,8 +1932,8 @@ paths:
                   description: >
                     Back of the document. Optional for every type, but
                     recommended for two-sided documents (national_id,
-                    kenya_id, drivers_license) — extraction may be less
-                    complete without it.
+                    kenya_id, drivers_license, voters_card) — extraction
+                    may be less complete without it.
                 selfie_image:
                   type: string
                   format: binary
@@ -1883,58 +1945,454 @@ paths:
                     with 400 if selfie_image is missing for any other type.
                     Still-image comparison only, not liveness.
       responses:
-        "200":
-          description: Document details extracted successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    example: "success"
-                  data:
-                    type: object
-                    properties:
-                      valid: { type: boolean }
-                      first_name: { type: string }
-                      last_name: { type: string }
-                      full_name: { type: string }
-                      date_of_birth: { type: string }
-                      gender: { type: string }
-                      nationality: { type: string }
-                      address: { type: string }
-                      id_number: { type: string }
-                      serial_number: { type: string }
-                      id_type: { type: string }
-                      document_type: { type: string }
-                      expiry_date: { type: string }
-                      issue_date: { type: string }
-                      is_expired: { type: boolean }
-                      photo:
-                        type: string
-                        description: Base64-encoded face photo extracted from the document. Absent for document types with no face photo (cac_certificate, utility_bill).
-                      extra_fields:
-                        type: object
-                        description: Every other field OCR read from the document that doesn't have its own dedicated field above. Varies by document_type and country.
-                      face_match:
-                        type: object
-                        description: Present only when selfie_image was supplied.
-                        properties:
-                          attempted: { type: boolean }
-                          verified:
-                            type: boolean
-                            nullable: true
-                            description: "true/false if the comparison ran; null if it couldn't (see reason)."
-                          confidence_percentage: { type: number }
-                          selfie_image:
-                            type: string
-                            description: URL of the uploaded selfie.
-                          reason:
-                            type: string
-                            description: Present when verified is null — explains why the comparison couldn't run or complete.
-                  message:
-                    type: string
-                    example: "Document details retrieved successfully"
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/nigeria/national_id:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — Nigeria National ID
+      operationId: documentVerificationNigeriaNationalId
+      description: >
+        Extract identity details from a Nigerian NIN slip or National ID
+        card using OCR, plus a required face match against a selfie.
+        document_type and country are fixed by this URL — no need to send
+        them in the request body.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Front of the NIN slip/card. JPG or PNG, max 5MB.
+                document_back:
+                  type: string
+                  format: binary
+                  description: >
+                    Back of the card. Optional, but recommended — extraction
+                    may be less complete without it.
+                selfie_image:
+                  type: string
+                  format: binary
+                  description: >
+                    A selfie to compare against the face extracted from the
+                    document. JPG or PNG, max 5MB. Required.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/nigeria/passport:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — Nigeria Passport
+      operationId: documentVerificationNigeriaPassport
+      description: >
+        Extract identity details from a Nigerian international passport
+        using OCR, plus a required face match against a selfie.
+        document_type and country are fixed by this URL — no need to send
+        them in the request body.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Photo of the passport data page. JPG or PNG, max 5MB.
+                selfie_image:
+                  type: string
+                  format: binary
+                  description: >
+                    A selfie to compare against the face extracted from the
+                    document. JPG or PNG, max 5MB. Required.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/nigeria/drivers_license:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — Nigeria Driver's License
+      operationId: documentVerificationNigeriaDriversLicense
+      description: >
+        Extract identity details from a Nigerian driver's license using
+        OCR, plus a required face match against a selfie. document_type
+        and country are fixed by this URL — no need to send them in the
+        request body.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Front of the driver's license. JPG or PNG, max 5MB.
+                document_back:
+                  type: string
+                  format: binary
+                  description: >
+                    Back of the license. Optional, but recommended —
+                    extraction may be less complete without it.
+                selfie_image:
+                  type: string
+                  format: binary
+                  description: >
+                    A selfie to compare against the face extracted from the
+                    document. JPG or PNG, max 5MB. Required.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/nigeria/voters_card:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — Nigeria Voter's Card
+      operationId: documentVerificationNigeriaVotersCard
+      description: >
+        Extract identity details from a Nigerian Permanent Voter's Card
+        (PVC) using OCR, plus a required face match against a selfie.
+        document_type and country are fixed by this URL — no need to send
+        them in the request body.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Photo of the PVC. JPG or PNG, max 5MB.
+                document_back:
+                  type: string
+                  format: binary
+                  description: >
+                    Back of the PVC. Optional, but recommended — extraction
+                    may be less complete without it.
+                selfie_image:
+                  type: string
+                  format: binary
+                  description: >
+                    A selfie to compare against the face extracted from the
+                    document. JPG or PNG, max 5MB. Required.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/nigeria/cac_certificate:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — Nigeria CAC Certificate
+      operationId: documentVerificationNigeriaCacCertificate
+      description: >
+        Extract company details from a Nigerian CAC certificate using OCR.
+        No face match — CAC certificates don't carry a photo, so
+        selfie_image is not applicable. document_type and country are
+        fixed by this URL — no need to send them in the request body.
+
+
+        Currently disabled pending relaunch — this endpoint returns 400
+        until re-enabled.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Photo of the CAC certificate. JPG or PNG, max 5MB.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/nigeria/utility_bill:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — Nigeria Utility Bill
+      operationId: documentVerificationNigeriaUtilityBill
+      description: >
+        Extract address details from a Nigerian utility bill using OCR.
+        No face match — utility bills don't carry a photo, so
+        selfie_image is not applicable. document_type and country are
+        fixed by this URL — no need to send them in the request body.
+
+
+        Currently disabled pending relaunch — this endpoint returns 400
+        until re-enabled.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Photo of the utility bill. JPG or PNG, max 5MB.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/kenya/kenya_id:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — Kenya ID
+      operationId: documentVerificationKenyaId
+      description: >
+        Extract identity details from a Kenyan ID card (older laminated
+        design or newer Maisha Card) using OCR, plus a required face match
+        against a selfie. Fields specific to the Maisha Card
+        (serial_number, place_of_issue, expiry date) come back empty on an
+        older card — that's expected, not an error. document_type and
+        country are fixed by this URL — no need to send them in the
+        request body.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Front of the ID card. JPG or PNG, max 5MB.
+                document_back:
+                  type: string
+                  format: binary
+                  description: >
+                    Back of the card. Optional, but recommended — extraction
+                    may be less complete without it.
+                selfie_image:
+                  type: string
+                  format: binary
+                  description: >
+                    A selfie to compare against the face extracted from the
+                    document. JPG or PNG, max 5MB. Required.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/kenya/passport:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — Kenya Passport
+      operationId: documentVerificationKenyaPassport
+      description: >
+        Extract identity details from a Kenyan passport using OCR, plus a
+        required face match against a selfie. document_type and country
+        are fixed by this URL — no need to send them in the request body.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Photo of the passport data page. JPG or PNG, max 5MB.
+                selfie_image:
+                  type: string
+                  format: binary
+                  description: >
+                    A selfie to compare against the face extracted from the
+                    document. JPG or PNG, max 5MB. Required.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/ghana/passport:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — Ghana Passport
+      operationId: documentVerificationGhanaPassport
+      description: >
+        Extract identity details from a Ghanaian passport using OCR, plus
+        a required face match against a selfie. document_type and country
+        are fixed by this URL — no need to send them in the request body.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Photo of the passport data page. JPG or PNG, max 5MB.
+                selfie_image:
+                  type: string
+                  format: binary
+                  description: >
+                    A selfie to compare against the face extracted from the
+                    document. JPG or PNG, max 5MB. Required.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/canada/passport:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — Canada Passport
+      operationId: documentVerificationCanadaPassport
+      description: >
+        Extract identity details from a Canadian passport using OCR, plus
+        a required face match against a selfie. document_type and country
+        are fixed by this URL — no need to send them in the request body.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Photo of the passport data page. JPG or PNG, max 5MB.
+                selfie_image:
+                  type: string
+                  format: binary
+                  description: >
+                    A selfie to compare against the face extracted from the
+                    document. JPG or PNG, max 5MB. Required.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/usa/passport:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — USA Passport
+      operationId: documentVerificationUsaPassport
+      description: >
+        Extract identity details from a US passport using OCR, plus a
+        required face match against a selfie. document_type and country
+        are fixed by this URL — no need to send them in the request body.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Photo of the passport data page. JPG or PNG, max 5MB.
+                selfie_image:
+                  type: string
+                  format: binary
+                  description: >
+                    A selfie to compare against the face extracted from the
+                    document. JPG or PNG, max 5MB. Required.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/cote_d_ivoire/passport:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — Cote d'Ivoire Passport
+      operationId: documentVerificationCoteDIvoirePassport
+      description: >
+        Extract identity details from a Cote d'Ivoire passport using OCR,
+        plus a required face match against a selfie. document_type and
+        country are fixed by this URL — no need to send them in the
+        request body.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Photo of the passport data page. JPG or PNG, max 5MB.
+                selfie_image:
+                  type: string
+                  format: binary
+                  description: >
+                    A selfie to compare against the face extracted from the
+                    document. JPG or PNG, max 5MB. Required.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/onboarding/document_verification/uk/passport:
+    post:
+      tags: [Document Verification]
+      summary: Document Verification — UK Passport
+      operationId: documentVerificationUkPassport
+      description: >
+        Extract identity details from a UK passport using OCR, plus a
+        required face match against a selfie. document_type and country
+        are fixed by this URL — no need to send them in the request body.
+        UK document verification currently supports passports only.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [document_front]
+              properties:
+                document_front:
+                  type: string
+                  format: binary
+                  description: Photo of the passport data page. JPG or PNG, max 5MB.
+                selfie_image:
+                  type: string
+                  format: binary
+                  description: >
+                    A selfie to compare against the face extracted from the
+                    document. JPG or PNG, max 5MB. Required.
+      responses:
+        "200": { $ref: "#/components/responses/DocumentVerificationSuccess" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }

--- a/v3/kyc/document_verification/canada/Passport.mdx
+++ b/v3/kyc/document_verification/canada/Passport.mdx
@@ -2,7 +2,7 @@
 title: "Passport"
 sidebarTitle: "Passport"
 description: "Extract identity details from a Canadian passport using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/canada/passport"
 ---
 
 Verify a customer's Canadian passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
@@ -18,7 +18,7 @@ Verify a customer's Canadian passport by uploading a photo of the data page — 
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/canada/passport
 ```
 
 ## Request
@@ -34,8 +34,6 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `passport` |
-| `country` | string | Yes | `canada` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
 | `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
@@ -43,23 +41,19 @@ POST /api/onboarding/document_verification
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/canada/passport" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=passport" \
-  -F "country=canada" \
   -F "document_front=@/path/to/passport.jpg" \
   -F "selfie_image=@/path/to/selfie.jpg"
 ```
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "passport");
-formData.append("country", "canada");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
 formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/canada/passport",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -73,9 +67,8 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/canada/passport",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "passport", "country": "canada"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
         "selfie_image": open("/path/to/selfie.jpg", "rb"),

--- a/v3/kyc/document_verification/cote_d_ivoire/Passport.mdx
+++ b/v3/kyc/document_verification/cote_d_ivoire/Passport.mdx
@@ -2,7 +2,7 @@
 title: "Passport"
 sidebarTitle: "Passport"
 description: "Extract identity details from a Côte d'Ivoire passport using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/cote_d_ivoire/passport"
 ---
 
 Verify a customer's Côte d'Ivoire passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
@@ -18,7 +18,7 @@ Verify a customer's Côte d'Ivoire passport by uploading a photo of the data pag
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/cote_d_ivoire/passport
 ```
 
 ## Request
@@ -34,8 +34,6 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `passport` |
-| `country` | string | Yes | `cote d'ivoire` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
 | `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
@@ -43,23 +41,19 @@ POST /api/onboarding/document_verification
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/cote_d_ivoire/passport" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=passport" \
-  -F "country=cote d'ivoire" \
   -F "document_front=@/path/to/passport.jpg" \
   -F "selfie_image=@/path/to/selfie.jpg"
 ```
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "passport");
-formData.append("country", "cote d'ivoire");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
 formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/cote_d_ivoire/passport",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -73,9 +67,8 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/cote_d_ivoire/passport",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "passport", "country": "cote d'ivoire"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
         "selfie_image": open("/path/to/selfie.jpg", "rb"),

--- a/v3/kyc/document_verification/ghana/Passport.mdx
+++ b/v3/kyc/document_verification/ghana/Passport.mdx
@@ -2,7 +2,7 @@
 title: "Passport"
 sidebarTitle: "Passport"
 description: "Extract identity details from a Ghanaian passport using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/ghana/passport"
 ---
 
 Verify a customer's Ghanaian passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
@@ -18,7 +18,7 @@ Verify a customer's Ghanaian passport by uploading a photo of the data page — 
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/ghana/passport
 ```
 
 ## Request
@@ -34,8 +34,6 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `passport` |
-| `country` | string | Yes | `ghana` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
 | `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
@@ -43,23 +41,19 @@ POST /api/onboarding/document_verification
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/ghana/passport" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=passport" \
-  -F "country=ghana" \
   -F "document_front=@/path/to/passport.jpg" \
   -F "selfie_image=@/path/to/selfie.jpg"
 ```
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "passport");
-formData.append("country", "ghana");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
 formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/ghana/passport",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -73,9 +67,8 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/ghana/passport",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "passport", "country": "ghana"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
         "selfie_image": open("/path/to/selfie.jpg", "rb"),

--- a/v3/kyc/document_verification/kenya/Kenya_ID.mdx
+++ b/v3/kyc/document_verification/kenya/Kenya_ID.mdx
@@ -2,7 +2,7 @@
 title: "Kenya National ID"
 sidebarTitle: "National ID"
 description: "Extract identity details from a Kenyan national ID card using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/kenya/kenya_id"
 ---
 
 Verify a customer's Kenyan national ID card by uploading a photo — no manual ID entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
@@ -18,7 +18,7 @@ Verify a customer's Kenyan national ID card by uploading a photo — no manual I
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/kenya/kenya_id
 ```
 
 ## Request
@@ -34,8 +34,6 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `kenya_id` |
-| `country` | string | Yes | `kenya` |
 | `document_front` | file | Yes | Front of the ID card. JPG or PNG, max 5MB |
 | `document_back` | file | No | Back of the ID card. JPG or PNG, max 5MB |
 | `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
@@ -44,10 +42,8 @@ POST /api/onboarding/document_verification
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/kenya/kenya_id" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=kenya_id" \
-  -F "country=kenya" \
   -F "document_front=@/path/to/id_front.jpg" \
   -F "document_back=@/path/to/id_back.jpg" \
   -F "selfie_image=@/path/to/selfie.jpg"
@@ -55,14 +51,12 @@ curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verific
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "kenya_id");
-formData.append("country", "kenya");
 formData.append("document_front", fs.createReadStream("/path/to/id_front.jpg"));
 formData.append("document_back", fs.createReadStream("/path/to/id_back.jpg"));
 formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/kenya/kenya_id",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -76,9 +70,8 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/kenya/kenya_id",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "kenya_id", "country": "kenya"},
     files={
         "document_front": open("/path/to/id_front.jpg", "rb"),
         "document_back": open("/path/to/id_back.jpg", "rb"),

--- a/v3/kyc/document_verification/kenya/Passport.mdx
+++ b/v3/kyc/document_verification/kenya/Passport.mdx
@@ -2,7 +2,7 @@
 title: "Passport"
 sidebarTitle: "Passport"
 description: "Extract identity details from a Kenyan passport using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/kenya/passport"
 ---
 
 Verify a customer's Kenyan passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
@@ -18,7 +18,7 @@ Verify a customer's Kenyan passport by uploading a photo of the data page — no
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/kenya/passport
 ```
 
 ## Request
@@ -34,8 +34,6 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `passport` |
-| `country` | string | Yes | `kenya` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
 | `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
@@ -43,23 +41,19 @@ POST /api/onboarding/document_verification
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/kenya/passport" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=passport" \
-  -F "country=kenya" \
   -F "document_front=@/path/to/passport.jpg" \
   -F "selfie_image=@/path/to/selfie.jpg"
 ```
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "passport");
-formData.append("country", "kenya");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
 formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/kenya/passport",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -73,9 +67,8 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/kenya/passport",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "passport", "country": "kenya"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
         "selfie_image": open("/path/to/selfie.jpg", "rb"),

--- a/v3/kyc/document_verification/nigeria/CAC_Certificate.mdx
+++ b/v3/kyc/document_verification/nigeria/CAC_Certificate.mdx
@@ -2,7 +2,7 @@
 title: "CAC Certificate"
 sidebarTitle: "CAC Certificate"
 description: "Extract business registration details from a CAC Certificate of Incorporation using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/nigeria/cac_certificate"
 ---
 
 Verify a business's CAC Certificate of Incorporation by uploading a photo — no manual RC number entry required. OCR extraction only. This document doesn't carry a face photo, so `data.photo` is omitted from the response entirely — face match isn't available for this document type; a `selfie_image` submitted alongside it is accepted but ignored (`face_match.attempted: false`).
@@ -11,10 +11,14 @@ Verify a business's CAC Certificate of Incorporation by uploading a photo — no
   Only `document_front` is needed for this document.
 </Note>
 
+<Note>
+  This endpoint is currently disabled pending relaunch and returns a 400 error until re-enabled.
+</Note>
+
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/nigeria/cac_certificate
 ```
 
 ## Request
@@ -30,29 +34,23 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `cac_certificate` |
-| `country` | string | Yes | `nigeria` |
 | `document_front` | file | Yes | Photo of the CAC certificate. JPG or PNG, max 5MB |
 
 ### Example
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/cac_certificate" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=cac_certificate" \
-  -F "country=nigeria" \
   -F "document_front=@/path/to/cac_certificate.jpg"
 ```
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "cac_certificate");
-formData.append("country", "nigeria");
 formData.append("document_front", fs.createReadStream("/path/to/cac_certificate.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/cac_certificate",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -66,9 +64,8 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/cac_certificate",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "cac_certificate", "country": "nigeria"},
     files={"document_front": open("/path/to/cac_certificate.jpg", "rb")},
 )
 data = response.json()

--- a/v3/kyc/document_verification/nigeria/Drivers_License.mdx
+++ b/v3/kyc/document_verification/nigeria/Drivers_License.mdx
@@ -2,7 +2,7 @@
 title: "Driver's License"
 sidebarTitle: "Driver's License"
 description: "Extract identity details from a Nigerian driver's license using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/nigeria/drivers_license"
 ---
 
 Verify a customer's Nigerian driver's license by uploading a photo — no manual license number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
@@ -18,7 +18,7 @@ Verify a customer's Nigerian driver's license by uploading a photo — no manual
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/nigeria/drivers_license
 ```
 
 ## Request
@@ -34,8 +34,6 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `drivers_license` |
-| `country` | string | Yes | `nigeria` |
 | `document_front` | file | Yes | Front of the driver's license. JPG or PNG, max 5MB |
 | `document_back` | file | No | Back of the driver's license. JPG or PNG, max 5MB |
 | `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
@@ -44,10 +42,8 @@ POST /api/onboarding/document_verification
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/drivers_license" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=drivers_license" \
-  -F "country=nigeria" \
   -F "document_front=@/path/to/license_front.jpg" \
   -F "document_back=@/path/to/license_back.jpg" \
   -F "selfie_image=@/path/to/selfie.jpg"
@@ -55,14 +51,12 @@ curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verific
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "drivers_license");
-formData.append("country", "nigeria");
 formData.append("document_front", fs.createReadStream("/path/to/license_front.jpg"));
 formData.append("document_back", fs.createReadStream("/path/to/license_back.jpg"));
 formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/drivers_license",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -76,9 +70,8 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/drivers_license",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "drivers_license", "country": "nigeria"},
     files={
         "document_front": open("/path/to/license_front.jpg", "rb"),
         "document_back": open("/path/to/license_back.jpg", "rb"),

--- a/v3/kyc/document_verification/nigeria/National_ID.mdx
+++ b/v3/kyc/document_verification/nigeria/National_ID.mdx
@@ -2,7 +2,7 @@
 title: "National ID"
 sidebarTitle: "National ID"
 description: "Extract identity details from a Nigerian NIN slip or card using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/nigeria/national_id"
 ---
 
 Verify a customer's Nigerian National Identification Number slip or card by uploading a photo — no manual NIN entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
@@ -18,7 +18,7 @@ Verify a customer's Nigerian National Identification Number slip or card by uplo
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/nigeria/national_id
 ```
 
 ## Request
@@ -34,20 +34,20 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `national_id` |
-| `country` | string | Yes | `nigeria` |
 | `document_front` | file | Yes | Front of the NIN slip/card. JPG or PNG, max 5MB |
 | `document_back` | file | No | Back of the NIN card. JPG or PNG, max 5MB |
 | `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
+
+<Note>
+  `document_type` and `country` are not needed — this endpoint is already scoped to Nigerian National ID.
+</Note>
 
 ### Example
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/national_id" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=national_id" \
-  -F "country=nigeria" \
   -F "document_front=@/path/to/nin_front.jpg" \
   -F "document_back=@/path/to/nin_back.jpg" \
   -F "selfie_image=@/path/to/selfie.jpg"
@@ -55,14 +55,12 @@ curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verific
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "national_id");
-formData.append("country", "nigeria");
 formData.append("document_front", fs.createReadStream("/path/to/nin_front.jpg"));
 formData.append("document_back", fs.createReadStream("/path/to/nin_back.jpg"));
 formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/national_id",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -76,9 +74,8 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/national_id",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "national_id", "country": "nigeria"},
     files={
         "document_front": open("/path/to/nin_front.jpg", "rb"),
         "document_back": open("/path/to/nin_back.jpg", "rb"),

--- a/v3/kyc/document_verification/nigeria/Passport.mdx
+++ b/v3/kyc/document_verification/nigeria/Passport.mdx
@@ -2,7 +2,7 @@
 title: "Passport"
 sidebarTitle: "Passport"
 description: "Extract identity details from a Nigerian international passport using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/nigeria/passport"
 ---
 
 Verify a customer's Nigerian international passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
@@ -18,7 +18,7 @@ Verify a customer's Nigerian international passport by uploading a photo of the 
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/nigeria/passport
 ```
 
 ## Request
@@ -34,32 +34,30 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `passport` |
-| `country` | string | Yes | `nigeria` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
 | `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
+
+<Note>
+  `document_type` and `country` are not needed — this endpoint is already scoped to Nigerian passports.
+</Note>
 
 ### Example
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/passport" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=passport" \
-  -F "country=nigeria" \
   -F "document_front=@/path/to/passport.jpg" \
   -F "selfie_image=@/path/to/selfie.jpg"
 ```
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "passport");
-formData.append("country", "nigeria");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
 formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/passport",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -73,9 +71,8 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/passport",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "passport", "country": "nigeria"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
         "selfie_image": open("/path/to/selfie.jpg", "rb"),

--- a/v3/kyc/document_verification/nigeria/Utility_Bill.mdx
+++ b/v3/kyc/document_verification/nigeria/Utility_Bill.mdx
@@ -2,7 +2,7 @@
 title: "Utility Bill"
 sidebarTitle: "Utility Bill"
 description: "Extract address and biller details from a utility bill using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/nigeria/utility_bill"
 ---
 
 Verify a customer's proof of address by uploading a photo of a utility bill — no manual data entry required. OCR extraction only. This document doesn't carry a face photo, so `data.photo` is omitted from the response entirely — face match isn't available for this document type; a `selfie_image` submitted alongside it is accepted but ignored (`face_match.attempted: false`).
@@ -11,10 +11,14 @@ Verify a customer's proof of address by uploading a photo of a utility bill — 
   Only `document_front` is needed for this document.
 </Note>
 
+<Note>
+  This endpoint is currently disabled pending relaunch and returns a 400 error until re-enabled.
+</Note>
+
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/nigeria/utility_bill
 ```
 
 ## Request
@@ -30,29 +34,23 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `utility_bill` |
-| `country` | string | Yes | `nigeria` |
 | `document_front` | file | Yes | Photo of the utility bill. JPG or PNG, max 5MB |
 
 ### Example
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/utility_bill" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=utility_bill" \
-  -F "country=nigeria" \
   -F "document_front=@/path/to/utility_bill.jpg"
 ```
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "utility_bill");
-formData.append("country", "nigeria");
 formData.append("document_front", fs.createReadStream("/path/to/utility_bill.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/utility_bill",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -66,9 +64,8 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/utility_bill",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "utility_bill", "country": "nigeria"},
     files={"document_front": open("/path/to/utility_bill.jpg", "rb")},
 )
 data = response.json()

--- a/v3/kyc/document_verification/nigeria/Voters_Card.mdx
+++ b/v3/kyc/document_verification/nigeria/Voters_Card.mdx
@@ -2,13 +2,13 @@
 title: "Voter's Card"
 sidebarTitle: "Voter's Card"
 description: "Extract identity details from a Nigerian Permanent Voter's Card (PVC) using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/nigeria/voters_card"
 ---
 
 Verify a customer's Nigerian Permanent Voter's Card (PVC) by uploading a photo — no manual voter ID entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
 
 <Note>
-  Only `document_front` is needed for this document.
+  This is a two-sided document — supply both `document_front` and `document_back` for the most complete extraction.
 </Note>
 
 <Note>
@@ -18,7 +18,7 @@ Verify a customer's Nigerian Permanent Voter's Card (PVC) by uploading a photo �
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/nigeria/voters_card
 ```
 
 ## Request
@@ -34,32 +34,29 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `voters_card` |
-| `country` | string | Yes | `nigeria` |
-| `document_front` | file | Yes | Photo of the PVC. JPG or PNG, max 5MB |
+| `document_front` | file | Yes | Photo of the front of the PVC. JPG or PNG, max 5MB |
+| `document_back` | file | No | Photo of the back of the PVC. JPG or PNG, max 5MB |
 | `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
 ### Example
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/voters_card" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=voters_card" \
-  -F "country=nigeria" \
-  -F "document_front=@/path/to/pvc.jpg" \
+  -F "document_front=@/path/to/pvc_front.jpg" \
+  -F "document_back=@/path/to/pvc_back.jpg" \
   -F "selfie_image=@/path/to/selfie.jpg"
 ```
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "voters_card");
-formData.append("country", "nigeria");
-formData.append("document_front", fs.createReadStream("/path/to/pvc.jpg"));
+formData.append("document_front", fs.createReadStream("/path/to/pvc_front.jpg"));
+formData.append("document_back", fs.createReadStream("/path/to/pvc_back.jpg"));
 formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/voters_card",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -73,11 +70,11 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/nigeria/voters_card",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "voters_card", "country": "nigeria"},
     files={
-        "document_front": open("/path/to/pvc.jpg", "rb"),
+        "document_front": open("/path/to/pvc_front.jpg", "rb"),
+        "document_back": open("/path/to/pvc_back.jpg", "rb"),
         "selfie_image": open("/path/to/selfie.jpg", "rb"),
     },
 )

--- a/v3/kyc/document_verification/uk/Passport.mdx
+++ b/v3/kyc/document_verification/uk/Passport.mdx
@@ -2,7 +2,7 @@
 title: "Passport"
 sidebarTitle: "Passport"
 description: "Extract identity details from a UK passport using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/uk/passport"
 ---
 
 Verify a customer's UK passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
@@ -22,7 +22,7 @@ Verify a customer's UK passport by uploading a photo of the data page — no man
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/uk/passport
 ```
 
 ## Request
@@ -38,8 +38,6 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `passport` |
-| `country` | string | Yes | `uk` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
 | `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
@@ -47,23 +45,19 @@ POST /api/onboarding/document_verification
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/uk/passport" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=passport" \
-  -F "country=uk" \
   -F "document_front=@/path/to/passport.jpg" \
   -F "selfie_image=@/path/to/selfie.jpg"
 ```
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "passport");
-formData.append("country", "uk");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
 formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/uk/passport",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -77,9 +71,8 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/uk/passport",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "passport", "country": "uk"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
         "selfie_image": open("/path/to/selfie.jpg", "rb"),

--- a/v3/kyc/document_verification/usa/Passport.mdx
+++ b/v3/kyc/document_verification/usa/Passport.mdx
@@ -2,7 +2,7 @@
 title: "Passport"
 sidebarTitle: "Passport"
 description: "Extract identity details from a United States passport using OCR."
-openapi: "POST /api/onboarding/document_verification"
+openapi: "POST /api/onboarding/document_verification/usa/passport"
 ---
 
 Verify a customer's United States passport by uploading a photo of the data page — no manual passport number entry required. OCR extraction plus a required face match against a selfie — no liveness check (no video, no blink/motion challenge).
@@ -18,7 +18,7 @@ Verify a customer's United States passport by uploading a photo of the data page
 ## Endpoint
 
 ```
-POST /api/onboarding/document_verification
+POST /api/onboarding/document_verification/usa/passport
 ```
 
 ## Request
@@ -34,8 +34,6 @@ POST /api/onboarding/document_verification
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|--------------|
-| `document_type` | string | Yes | `passport` |
-| `country` | string | Yes | `usa` |
 | `document_front` | file | Yes | Photo of the passport data page. JPG or PNG, max 5MB |
 | `selfie_image` | file | Yes | A selfie to compare against the document's face photo. JPG or PNG, max 5MB |
 
@@ -43,23 +41,19 @@ POST /api/onboarding/document_verification
 
 <CodeGroup>
 ```bash cURL
-curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification" \
+curl -X POST "https://adhere-api.smartcomply.com/api/onboarding/document_verification/usa/passport" \
   -H "x-access-token: YOUR_SECRET_KEY" \
-  -F "document_type=passport" \
-  -F "country=usa" \
   -F "document_front=@/path/to/passport.jpg" \
   -F "selfie_image=@/path/to/selfie.jpg"
 ```
 
 ```javascript Node.js
 const formData = new FormData();
-formData.append("document_type", "passport");
-formData.append("country", "usa");
 formData.append("document_front", fs.createReadStream("/path/to/passport.jpg"));
 formData.append("selfie_image", fs.createReadStream("/path/to/selfie.jpg"));
 
 const response = await fetch(
-  "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+  "https://adhere-api.smartcomply.com/api/onboarding/document_verification/usa/passport",
   {
     method: "POST",
     headers: { "x-access-token": "YOUR_SECRET_KEY" },
@@ -73,9 +67,8 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    "https://adhere-api.smartcomply.com/api/onboarding/document_verification",
+    "https://adhere-api.smartcomply.com/api/onboarding/document_verification/usa/passport",
     headers={"x-access-token": "YOUR_SECRET_KEY"},
-    data={"document_type": "passport", "country": "usa"},
     files={
         "document_front": open("/path/to/passport.jpg", "rb"),
         "selfie_image": open("/path/to/selfie.jpg", "rb"),


### PR DESCRIPTION
Every document-verification page previously pointed at one shared operation (POST /api/onboarding/document_verification), so the "Try it" playground always showed a generic document_type/country dropdown regardless of which country's page you were viewing — confirmed Mintlify has no supported mechanism to pre-fill different defaults per page for a shared operation (github.com/orgs/mintlify/discussions/759).

Backend now exposes a dedicated URL per country/document-type combination (adhere-backend PR fix/ivs-nigeria-passport-rename-and-dropdown-fixes) — this updates the docs to match:

- openapi.yaml: added 13 new operations, one per dedicated endpoint (Nigeria x6, Kenya x2, Ghana/Canada/USA/Cote d'Ivoire/UK x1 each), each with document_type/country removed from the request schema since they're now fixed by the URL. Original generic /document_verification operation kept as-is for backward compatibility. Added a shared DocumentVerificationSuccess response component so the large 200 schema isn't duplicated 14 times. Also added "uk" to the generic endpoint's country enum, which was missing it.
- Every document-verification .mdx page (13 total) updated to point at its own dedicated URL in frontmatter, endpoint block, and all three code examples (cURL/Node/Python) — document_type and country dropped from body parameter tables and request bodies since they're no longer needed.
- Nigeria Voter's Card: fixed a doc gap found while updating this page — it said "only document_front is needed" but the backend now accepts (and recommends) document_back too. Updated to match the two-sided document pattern used by National ID/Driver's License.
- Nigeria CAC Certificate / Utility Bill: added a note that these endpoints are currently disabled pending relaunch (matches their enabled=False state in the backend).

Verified: openapi.yaml and docs.json both parse as valid, 83 operationIds across the spec with zero duplicates, all 13 new paths present and distinct, every doc page's frontmatter URL confirmed present in the spec, zero leftover document_type/country references in any updated page.