### PR TITLE
docs: correct SDK pages against production E2E findings

### DIFF
--- a/error_codes.mdx
+++ b/error_codes.mdx
@@ -13,8 +13,11 @@ The Adhere API uses standard HTTP status codes. Codes in the `2xx` range indicat
 | `400` | Bad Request | The request was malformed — a required parameter is missing, the value is invalid, or the request body is not valid JSON. |
 | `401` | Unauthenticated | The `x-access-token` header is missing or the key is invalid. |
 | `403` | Forbidden | The API key is valid but does not have permission to access this endpoint. |
+| `402` | Payment Required | Your wallet balance is too low to run the check, or no wallet is configured for the branch. |
 | `404` | Not Found | The requested resource does not exist. |
+| `409` | Conflict | The resource is already in the requested state — for example, a verification that has already been submitted. |
 | `422` | Unprocessable Entity | The request was well-formed but the data failed validation (e.g., an ID number that doesn't match the expected format). |
+| `429` | Too Many Requests | A rate limit or a retry limit was exceeded. Back off and retry. |
 | `500` | Internal Server Error | An unexpected error occurred on Smartcomply's end. |
 | `502` | Bad Gateway | A dependent upstream service is temporarily unavailable. |
 | `503` | Service Unavailable | The API is temporarily offline for maintenance. |
@@ -85,4 +88,33 @@ For `5xx` errors and network timeouts, retry with exponential back-off:
 | 2nd retry | 2 seconds |
 | 3rd retry | 4 seconds |
 
-Do **not** retry `4xx` errors — they indicate a problem with the request itself that must be fixed before retrying.
+Do **not** retry other `4xx` errors — they indicate a problem with the request itself that must be fixed before retrying. `429` is the exception: back off and retry it.
+
+## SDK Error Codes
+
+Requests made by the Web, Android and iOS SDKs use a different response envelope from the rest of the API. It carries a machine-readable `code` and a `request_id`:
+
+```json
+{
+  "status": "error",
+  "code": "SDK_CONFIG_NOT_FOUND",
+  "message": "No active SDK configuration found for this client_id.",
+  "data": { "client_id": "..." },
+  "request_id": "req_a1b2c3d4e5f6"
+}
+```
+
+Quote the `request_id` when contacting support — it identifies the exact request in our logs.
+
+| Code | HTTP | Cause | Fix |
+|------|------|-------|-----|
+| `INVALID_API_KEY` | `401` | The API key is missing, malformed, unknown, or the branch is not enabled for onboarding | Check your key under **Settings → API Keys** |
+| `SDK_CONFIG_NOT_FOUND` | `404` | `clientId` does not match an active SDK Config | Copy the Client ID from **Settings → Integrations → SDK Setup**. Do not generate one per attempt |
+| `VALIDATION_ERROR` | `400` | One or more request fields failed validation | Read `data.errors` for the failing field and reason |
+| `INVALID_SESSION` | `401` | The session token is missing, malformed or expired (30-minute lifetime) | Start a new session. Your `apiKey` and `clientId` stay the same |
+| `RETRY_LIMIT_EXCEEDED` | `429` | Three failed verification attempts on one session | The user must start again with a new session |
+| `ALREADY_SUBMITTED` | `409` | This verification has already been submitted | Read the outcome from the webhook rather than resubmitting |
+| `WALLET_NOT_FOUND` | `402` | No wallet is configured for the branch | Contact support |
+| `INSUFFICIENT_BALANCE` | `402` | Wallet balance is below the cost of the check. `data.required_amount` holds the shortfall | Top up your wallet in the dashboard |
+| `SUBMISSION_FAILED` | `500` | The verification could not be saved | Retry with back-off; if it persists, contact support |
+| `INTERNAL_ERROR` | `500` | Unexpected server-side error | Retry with back-off; quote the `request_id` if it persists |

--- a/libraries/android_sdk.mdx
+++ b/libraries/android_sdk.mdx
@@ -12,7 +12,7 @@ The SmartComply Android SDK delivers a fully self-contained identity verificatio
 - **Single-Activity launch** — start verification with one Intent and receive a typed result back
 - **Two verification modes** — document photo capture or ID number data entry, configured from your Dashboard
 - **Guide-box document capture** — frames the ID card precisely so images are always clean and correctly cropped
-- **Liveness detection** — camera-based face challenge system (blink, turn head) runs automatically after identity verification
+- **Liveness detection** — a passive camera scan (blink plus natural head movement) runs automatically after identity verification, with no step-by-step prompts
 - **Dynamic ID types** — channels and fields are fetched live from your Dashboard configuration
 - **Multi-country support** — renders a country picker automatically when more than one country is configured
 - **Dark and light mode** — theme adapts to the system setting; override via the launch intent
@@ -22,7 +22,8 @@ The SmartComply Android SDK delivers a fully self-contained identity verificatio
 ## Requirements
 
 - **Android API 24** (Android 7.0) or later
-- **Kotlin 1.9** or later
+- **Kotlin 2.1** or later — the SDK is compiled with the Kotlin 2.1 toolchain, so an older consumer compiler rejects it
+- **Java 17** — the SDK targets JVM 17
 - **Jetpack Compose** enabled in your module
 
 ---
@@ -64,6 +65,21 @@ android {
 
 ---
 
+## Credentials
+
+Both values come from your Adhere Dashboard and both are permanent. Reuse the same pair for every verification.
+
+| Value | Where to find it | Notes |
+|---|---|---|
+| `apiKey` | **Settings → API Keys** | A 64-character alphanumeric string with no prefix |
+| `clientId` | **Settings → Integrations → SDK Setup**, then the row menu → **Integration → Client ID** | The UUID of your SDK Config. It is issued by Adhere — do not generate one |
+
+<Warning>
+  `clientId` is not a per-attempt value. Generating your own UUID returns `404 SDK_CONFIG_NOT_FOUND` on the very first call, because the server resolves it against an existing SDK Config record.
+</Warning>
+
+---
+
 ## Permissions
 
 The SDK declares these permissions automatically via manifest merge. You do not need to add them manually unless your project uses a custom manifest merge strategy:
@@ -73,7 +89,7 @@ The SDK declares these permissions automatically via manifest merge. You do not 
 <uses-permission android:name="android.permission.INTERNET" />
 ```
 
-The SDK requests the `CAMERA` permission at runtime before the camera is used. Your app does not need to request it separately.
+`SmartComplyActivity` requests the `CAMERA` permission at runtime before it starts the flow, so if you launch through the Activity your app does not need to request it separately. If you embed `SmartComplyFlowScreen` directly, see [Advanced: Custom Host Activity](#advanced-custom-host-activity).
 
 ---
 
@@ -86,7 +102,6 @@ In your `Activity` or `Fragment`:
 ```kotlin
 import androidx.activity.result.contract.ActivityResultContracts
 import com.smartcomply.sdk.ui.SmartComplyActivity
-import com.smartcomply.sdk.types.FlowResult
 
 val verificationLauncher = registerForActivityResult(
     ActivityResultContracts.StartActivityForResult()
@@ -94,15 +109,11 @@ val verificationLauncher = registerForActivityResult(
     val data = result.data ?: return@registerForActivityResult
     when (data.getStringExtra(SmartComplyActivity.RESULT_TYPE)) {
         SmartComplyActivity.TYPE_SUCCESS -> {
-            val entryId      = data.getIntExtra(SmartComplyActivity.RESULT_ENTRY_ID, -1)
-            val status       = data.getStringExtra(SmartComplyActivity.RESULT_STATUS)
-            val verifiedName = data.getStringExtra(SmartComplyActivity.RESULT_VERIFIED_NAME)
-            val idTypeName   = data.getStringExtra(SmartComplyActivity.RESULT_ID_TYPE_NAME)
-            // handle success
-        }
-        SmartComplyActivity.TYPE_FAILURE -> {
-            val errorMsg = data.getStringExtra(SmartComplyActivity.RESULT_ERROR_MSG)
-            // handle error
+            val entryId    = data.getIntExtra(SmartComplyActivity.RESULT_ENTRY_ID, -1)
+            val status     = data.getStringExtra(SmartComplyActivity.RESULT_STATUS)
+            val idTypeName = data.getStringExtra(SmartComplyActivity.RESULT_ID_TYPE_NAME)
+            // The user has finished their part of the flow. `status` is "processing";
+            // the pass or fail verdict arrives later by webhook.
         }
         SmartComplyActivity.TYPE_CANCELLED -> {
             // user pressed back
@@ -115,12 +126,11 @@ val verificationLauncher = registerForActivityResult(
 
 ```kotlin
 import com.smartcomply.sdk.client.Environment
-import java.util.UUID
 
 val intent = SmartComplyActivity.buildIntent(
     from        = this,
-    apiKey      = "pk_live_xxxxxxxxxxxx",   // your SmartComply API key
-    clientId    = UUID.randomUUID().toString(), // unique per verification attempt
+    apiKey      = "YOUR_API_KEY",     // Settings → API Keys
+    clientId    = "YOUR_CLIENT_ID",   // Settings → Integrations → SDK Setup
     environment = Environment.PRODUCTION
 )
 verificationLauncher.launch(intent)
@@ -133,10 +143,9 @@ If you are launching from a composable, use `rememberLauncherForActivityResult`:
 ```kotlin
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
 import com.smartcomply.sdk.ui.SmartComplyActivity
 import com.smartcomply.sdk.client.Environment
-import java.util.UUID
 
 @Composable
 fun StartVerificationButton() {
@@ -147,8 +156,7 @@ fun StartVerificationButton() {
     ) { result ->
         val data = result.data ?: return@rememberLauncherForActivityResult
         when (data.getStringExtra(SmartComplyActivity.RESULT_TYPE)) {
-            SmartComplyActivity.TYPE_SUCCESS   -> { /* handle success */ }
-            SmartComplyActivity.TYPE_FAILURE   -> { /* handle error */ }
+            SmartComplyActivity.TYPE_SUCCESS   -> { /* handle submission */ }
             SmartComplyActivity.TYPE_CANCELLED -> { /* user cancelled */ }
         }
     }
@@ -156,8 +164,8 @@ fun StartVerificationButton() {
     Button(onClick = {
         val intent = SmartComplyActivity.buildIntent(
             from        = context,
-            apiKey      = "pk_live_xxxxxxxxxxxx",
-            clientId    = UUID.randomUUID().toString(),
+            apiKey      = "YOUR_API_KEY",
+            clientId    = "YOUR_CLIENT_ID",
             environment = Environment.PRODUCTION
         )
         launcher.launch(intent)
@@ -184,10 +192,25 @@ fun buildIntent(
 | Parameter | Default | Description |
 |---|---|---|
 | `from` | — | The calling `Context` |
-| `apiKey` | — | Your SmartComply API key — find it in the Dashboard |
-| `clientId` | — | A unique ID per verification attempt — use `UUID.randomUUID().toString()` |
+| `apiKey` | — | Your Adhere API key — find it in the Dashboard |
+| `clientId` | — | Your SDK Config's Client ID from the Dashboard. Permanent — reuse it for every verification |
 | `darkTheme` | `null` | `true` forces dark mode, `false` forces light, `null` follows the device setting |
-| `environment` | `PRODUCTION` | `PRODUCTION` for live verification, `SANDBOX` for testing |
+| `environment` | `PRODUCTION` | See [Environments](#environments) below |
+
+---
+
+## Environments
+
+| Value | Base URL |
+|---|---|
+| `Environment.PRODUCTION` | `https://adhere-api.smartcomply.com` |
+| `Environment.SANDBOX` | `http://localhost:8000` |
+
+`SANDBOX` targets a server running on the handset itself, for local backend development. It is not a hosted test environment. Use `PRODUCTION` for all integration work.
+
+<Note>
+  `SmartComplyActivity.buildIntent` defaults to `PRODUCTION`, but the `SDKConfig` constructor used by the [embedded flow](#advanced-custom-host-activity) defaults to `SANDBOX`. Set `environment` explicitly when you construct `SDKConfig` yourself.
+</Note>
 
 ---
 
@@ -197,31 +220,42 @@ Read from the `Intent` returned to your activity result callback.
 
 | Constant | Type | Present when |
 |---|---|---|
-| `RESULT_TYPE` | `String` | Always — `"success"`, `"failure"`, or `"cancelled"` |
-| `RESULT_ENTRY_ID` | `Int` | `TYPE_SUCCESS` |
-| `RESULT_STATUS` | `String` | `TYPE_SUCCESS` — e.g. `"submitted"`, `"verified"` |
+| `RESULT_TYPE` | `String` | Always — `"success"` or `"cancelled"` |
+| `RESULT_ENTRY_ID` | `Int` | `TYPE_SUCCESS` — the verification's entry ID |
+| `RESULT_STATUS` | `String` | `TYPE_SUCCESS` — `"processing"` |
 | `RESULT_SUBMITTED_AT` | `String` | `TYPE_SUCCESS` — ISO 8601 timestamp |
-| `RESULT_VERIFIED_NAME` | `String` | `TYPE_SUCCESS` — full name from the identity provider, if available |
-| `RESULT_ID_TYPE_NAME` | `String` | `TYPE_SUCCESS` — e.g. `"National ID"`, `"BVN"` |
-| `RESULT_ERROR_MSG` | `String` | `TYPE_FAILURE` |
+| `RESULT_ID_TYPE_NAME` | `String` | `TYPE_SUCCESS` — e.g. `"National Identity Number (NIN)"`, `"Passport"` |
+| `RESULT_ID_NUMBER` | `String` | `TYPE_SUCCESS` — the ID number the user entered, in data mode |
+
+<Note>
+  **The result is a submission receipt, not a verification verdict.** `RESULT_STATUS` is `"processing"` when the user finishes: face matching, document OCR and the government database check all continue after the Activity returns. An entry's status moves through `pending`, `processing`, and then `passed`, `failed` or `expired`. The final outcome arrives via [webhook](/webhooks#identity-verification).
+</Note>
+
+`TYPE_CANCELLED` is returned whenever the user leaves via the back button, including from the success screen. Treat `RESULT_ENTRY_ID` as the only reliable handle on a run, and reconcile the outcome from the webhook.
 
 ---
 
 ## Verification Flow
 
-The SDK steps through these states automatically.
+The SDK steps through these screens automatically.
 
 | Step | Description |
 |---|---|
 | Loading | Session creation and brand config fetch |
 | Welcome | Brand splash, country picker, and ID type selection |
-| Camera Permission | Requests camera permission at runtime before any camera is opened |
-| Document Capture | Camera view for the front (and back, if required) of the ID document |
+| Camera Permission | Requests camera permission at runtime, in document mode |
+| Camera Permission Denied | "Camera Access Required" screen with **Open Settings** and **Go Back** |
+| Document Capture (front) | Camera view with a guide box, a shutter, and **Upload from gallery** |
+| Document Capture (back) | Shown for ID types whose name contains national, driver, resident or voter |
 | ID Input | Form fields for data-mode verification (BVN, NIN, etc.) |
-| Liveness | Live camera challenge — blink, turn head |
-| Processing | Upload and backend verification in progress |
-| Success | Verification complete — shows a summary card, then calls back |
-| Failure | Unrecoverable error — shows the message and a retry button |
+| Liveness | Passive camera scan — blink plus natural head movement, detected without naming the actions |
+| Processing | Upload and backend submission in progress |
+| Success | Submission complete — shows a summary card, then returns the result |
+| Failure | Error screen with a retry button |
+
+### Document images
+
+Document photos are capped at **5 MB** server-side, in JPG or PNG. Photos taken with the in-SDK camera are downscaled and compressed automatically. Images chosen with **Upload from gallery** are uploaded as-is, so a full-resolution phone photo can exceed the limit and fail with `File too large. Maximum size is 5MB.`
 
 ---
 
@@ -231,7 +265,7 @@ The SDK steps through these states automatically.
 data class SDKConfig(
     val apiKey:             String,
     val clientId:           String,
-    val environment:        Environment = Environment.PRODUCTION,
+    val environment:        Environment = Environment.SANDBOX,
     val requestTimeoutMs:   Long        = 30_000L,
     val uploadTimeoutMs:    Long        = 120_000L,
     val maxUploadRetries:   Int         = 3,
@@ -241,27 +275,26 @@ data class SDKConfig(
 
 | Parameter | Default | Description |
 |---|---|---|
-| `apiKey` | — | Your SmartComply API key (required) |
-| `clientId` | — | Unique identifier per verification attempt (required) |
-| `environment` | `PRODUCTION` | `SANDBOX` for testing, `PRODUCTION` for live verification |
-| `requestTimeoutMs` | `30000` | Timeout in milliseconds for standard API calls |
-| `uploadTimeoutMs` | `120000` | Timeout in milliseconds for video upload |
-| `maxUploadRetries` | `3` | Automatic retry attempts on upload failure |
+| `apiKey` | — | Your Adhere API key (required) |
+| `clientId` | — | Your SDK Config's Client ID (required) |
+| `environment` | `SANDBOX` | Set this explicitly — see [Environments](#environments) |
+| `requestTimeoutMs` | `30000` | Timeout in milliseconds for standard API calls, including identity verification |
+| `uploadTimeoutMs` | `120000` | Timeout in milliseconds for image and video upload |
+| `maxUploadRetries` | `3` | Automatic retry attempts when creating a liveness check. The final submit is not retried |
 | `debug` | `false` | Prints verbose network logs to Logcat when `true` |
 
 ---
 
 ## Error Handling
 
-`SmartComplyActivity` handles and displays all error states automatically. Common scenarios:
+`SmartComplyActivity` handles and displays all error states inside the flow — an invalid key, an expired session, or an exhausted upload retry all render the SDK's own failure screen with a **Try Again** button. The Activity returns a result only when the user completes the flow or backs out.
 
 | Scenario | Cause | Resolution |
 |---|---|---|
-| `TYPE_FAILURE` with `"401"` | Invalid or missing API key | Check your key in the SmartComply Dashboard |
-| `TYPE_FAILURE` — session expired | Session tokens have a 30-minute TTL | Generate a new `clientId` on the next launch |
-| `TYPE_FAILURE` — liveness timed out | The passive liveness scan has its own 12-second capture window, separate from the 30-minute session TTL. This timer only runs during the active scan (once the camera has centered and locked onto the face) and is cleared as soon as the scan resolves — it never applies retroactively to a step the user has already finished, and doesn't run while the user is elsewhere in the flow. | The built-in "Time's Up" screen offers a retry against the same liveness entry — no need to restart the whole flow |
-| `TYPE_CANCELLED` | User pressed back | Re-launch when the user is ready to retry |
-| Upload failed | Network instability | The built-in failure screen offers a retry; if retries are exhausted `TYPE_FAILURE` is returned |
+| Failure screen, invalid key | `apiKey` is wrong or the branch is not enabled for onboarding | Check your key in the Adhere Dashboard |
+| Failure screen, no configuration found | `clientId` is not an active SDK Config | Copy the Client ID from **Settings → Integrations → SDK Setup**. Do not generate a UUID |
+| Failure screen, session expired | Session tokens have a 30-minute TTL | Relaunch. A new session is created on each launch; your `clientId` never changes |
+| `TYPE_CANCELLED` | User pressed back, from any screen | Reconcile against the webhook before assuming the user abandoned the flow |
 
 ---
 
@@ -274,13 +307,12 @@ import com.smartcomply.sdk.SmartComply
 import com.smartcomply.sdk.client.SDKConfig
 import com.smartcomply.sdk.client.Environment
 import com.smartcomply.sdk.ui.SmartComplyFlowScreen
-import java.util.UUID
 
 val sdk = SmartComply(
     SDKConfig(
-        apiKey      = "pk_live_xxxxxxxxxxxx",
-        clientId    = UUID.randomUUID().toString(),
-        environment = Environment.PRODUCTION
+        apiKey      = "YOUR_API_KEY",
+        clientId    = "YOUR_CLIENT_ID",
+        environment = Environment.PRODUCTION   // required: SDKConfig defaults to SANDBOX
     )
 )
 
@@ -289,23 +321,24 @@ SmartComplyFlowScreen(
     sdk        = sdk,
     darkTheme  = null,            // null = follow system setting
     onComplete = { result ->
-        // result.entryId, result.status, result.verifiedName, etc.
-    },
-    onError = { message ->
-        // unrecoverable error not handled by the built-in failure screen
+        // result.entryId, result.status, result.submittedAt
     }
 )
 ```
 
 <Warning>
-Your host `Activity` must be a `ComponentActivity` and must be in the foreground with an active window. Embedding `SmartComplyFlowScreen` inside a `Dialog` or bottom sheet will cause the camera to fail on some devices.
+  Your host `Activity` must be a `ComponentActivity` and must be in the foreground with an active window. Embedding `SmartComplyFlowScreen` inside a `Dialog` or bottom sheet will cause the camera to fail on some devices.
+</Warning>
+
+<Warning>
+  **Request `CAMERA` yourself before entering the flow.** The composable only routes through its own permission screen in document mode. In data mode it goes straight from ID input to liveness, so if the permission has not been granted the camera never opens. `SmartComplyActivity` does not have this problem because it requests the permission up front for both modes.
 </Warning>
 
 ---
 
 ## ProGuard / R8
 
-The SDK ships with its own consumer ProGuard rules. If you see obfuscation-related issues, add to your `proguard-rules.pro`:
+The SDK does not ship consumer ProGuard rules, and it resolves kotlinx.serialization serializers reflectively. If you minify your release build, add these rules to your `proguard-rules.pro`:
 
 ```
 -keep class com.smartcomply.sdk.** { *; }

--- a/libraries/ios_sdk.mdx
+++ b/libraries/ios_sdk.mdx
@@ -12,11 +12,11 @@ The SmartComply iOS SDK is a native Swift library that delivers a fully self-con
 - **Drop-in SwiftUI view** — `SmartComplyFlowView` manages the entire verification flow with no UI code required
 - **Two verification modes** — document photo capture or ID number data entry, configured from your Dashboard
 - **Guide-box document capture** — crops exactly what falls inside the ID card frame so the image sent to the backend is always clean
-- **Liveness detection** — face challenge system (blink, turn head) runs automatically after identity verification
+- **Liveness detection** — a passive face scan (blink plus natural head movement) runs automatically after identity verification, with no step-by-step prompts
 - **Dynamic ID types** — channels and fields are fetched live from your Dashboard configuration
 - **Multi-country support** — renders a country picker automatically when more than one country is configured
 - **Dark and light mode** — theme adapts to the system colour scheme; override with `preferredColorScheme`
-- **Automatic retry** — handles upload retries and session errors internally
+- **Automatic upload retry** — transient upload failures are retried internally
 
 ---
 
@@ -25,7 +25,7 @@ The SmartComply iOS SDK is a native Swift library that delivers a fully self-con
 - **iOS 16.0** or later
 - **Swift 5.9** or later
 - **Xcode 15** or later
-- **iPhone X or later** — liveness detection requires a front-facing TrueDepth camera
+- **A physical device that supports ARKit face tracking.** Liveness gates on `ARFaceTrackingConfiguration.isSupported`, which covers iPhone X and later as well as A12 and later devices without a TrueDepth camera. Liveness cannot run in the Simulator
 
 ---
 
@@ -68,25 +68,46 @@ Add the following key to your app's `Info.plist`:
 <string>Camera access is required to photograph your ID document and complete liveness verification.</string>
 ```
 
+This is the only usage-description key the SDK needs. It records no audio, and the **Upload from library** control uses `PHPickerViewController`, which runs out of process and requires no photo-library key.
+
+---
+
+## Credentials
+
+Both values come from your Adhere Dashboard and both are permanent. Reuse the same pair for every verification.
+
+| Value | Where to find it | Notes |
+|---|---|---|
+| `apiKey` | **Settings → API Keys** | A 64-character alphanumeric string with no prefix |
+| `clientId` | **Settings → Integrations → SDK Setup**, then the row menu → **Integration → Client ID** | The UUID of your SDK Config. It is issued by Adhere — do not generate one |
+
+<Warning>
+  `clientId` is not a per-attempt value. Generating your own UUID returns `404 SDK_CONFIG_NOT_FOUND` on the very first call, because the server resolves it against an existing SDK Config record.
+</Warning>
+
 ---
 
 ## Quick Start
 
 ### 1. Create the SDK instance
 
-Create a `SmartComply` instance once — for example in your view model or app entry point. Generate a fresh `clientId` (UUID) for each new verification attempt.
+Create a `SmartComply` instance once, for example in your view model or app entry point.
 
 ```swift
 import SmartComplySDK
 
 let sdk = SmartComply(
     config: SDKConfig(
-        apiKey:      "pk_live_xxxxxxxxxxxx",
-        clientId:    UUID().uuidString,       // unique per verification attempt
+        apiKey:      "YOUR_API_KEY",
+        clientId:    "YOUR_CLIENT_ID",
         environment: .production
     )
 )
 ```
+
+<Warning>
+  Always pass `environment` explicitly. `SDKConfig` defaults to `.sandbox`, which points at `http://localhost:8000` — see [Environments](#environments).
+</Warning>
 
 ### 2. Present the flow view
 
@@ -97,7 +118,13 @@ import SmartComplySDK
 
 struct ContentView: View {
     @State private var showVerification = false
-    let sdk = SmartComply(config: SDKConfig(apiKey: "pk_live_...", clientId: UUID().uuidString))
+    let sdk = SmartComply(
+        config: SDKConfig(
+            apiKey:      "YOUR_API_KEY",
+            clientId:    "YOUR_CLIENT_ID",
+            environment: .production
+        )
+    )
 
     var body: some View {
         Button("Verify Identity") {
@@ -107,10 +134,7 @@ struct ContentView: View {
             SmartComplyFlowView(sdk: sdk) { result in
                 showVerification = false
                 print("Entry ID:", result.entryId)
-                print("Status:", result.status)
-                if let name = result.verifiedName {
-                    print("Verified name:", name)
-                }
+                print("Status:", result.status)   // "processing"
             }
         }
     }
@@ -124,8 +148,8 @@ The SDK manages the entire flow automatically. The exact steps depend on the ver
 2. Displays a welcome screen with your brand name and ID type cards
 3. Shows a country picker if multiple countries are configured
 4. User photographs the front of their ID inside the guide box
-5. Photographs the back if required (National ID, Driver's Licence, Voter's Card)
-6. Runs liveness face challenges
+5. Photographs the back if the ID type's name contains national, driver, resident or voter
+6. Runs the passive liveness scan
 7. Returns a `FlowResult` to your completion handler
 
 **Data mode** (ID number entry):
@@ -134,8 +158,19 @@ The SDK manages the entire flow automatically. The exact steps depend on the ver
 3. Shows a country picker if multiple countries are configured
 4. User enters their ID number and any required fields
 5. Identity is verified against the national database
-6. Runs liveness face challenges
+6. Runs the passive liveness scan
 7. Returns a `FlowResult` to your completion handler
+
+---
+
+## Environments
+
+| Value | Base URL |
+|---|---|
+| `.production` | `https://adhere-api.smartcomply.com` |
+| `.sandbox` | `http://localhost:8000` |
+
+`.sandbox` targets a server running on the device itself, for local backend development. It is not a hosted test environment. Use `.production` for all integration work.
 
 ---
 
@@ -157,13 +192,13 @@ public struct SDKConfig {
 
 | Parameter | Default | Description |
 |---|---|---|
-| `apiKey` | — | Your SmartComply API key (required) |
-| `clientId` | — | A unique identifier per verification attempt — use `UUID().uuidString` (required) |
-| `environment` | `.sandbox` | `.sandbox` for testing; `.production` for live traffic |
-| `requestTimeout` | `30` | Timeout in seconds for standard API calls |
-| `uploadTimeout` | `120` | Timeout in seconds for video upload |
-| `maxUploadRetries` | `3` | Number of automatic retry attempts on upload failure |
-| `debug` | `false` | Prints verbose network logs to the console when `true` |
+| `apiKey` | — | Your Adhere API key (required) |
+| `clientId` | — | Your SDK Config's Client ID (required) |
+| `environment` | `.sandbox` | Set this explicitly — see [Environments](#environments) |
+| `requestTimeout` | `30` | Timeout in seconds for standard API calls, including identity verification |
+| `uploadTimeout` | `120` | Timeout in seconds for image and video upload |
+| `maxUploadRetries` | `3` | Total upload attempts, not retries after the first. Only transport failures are retried; an API error is surfaced immediately |
+| `debug` | `false` | Writes verbose network logs to the unified log (`os.Logger`, subsystem `com.smartcomply.sdk`) when `true`. Read them in Console.app — they do not appear in Xcode's console pane |
 
 ---
 
@@ -173,15 +208,17 @@ Delivered to your `onComplete` closure when the user completes the flow in-app.
 
 ```swift
 public struct FlowResult {
-    public let entryId: Int          // liveness entry ID — use this to query results via the API
-    public let status: String        // e.g. "submitted"
-    public let submittedAt: String?  // ISO 8601 timestamp
-    public let idTypeName: String?   // e.g. "National ID", "BVN"
-    public let verifiedName: String? // name returned by the identity provider (data mode only)
+    public let entryId: Int                              // verification entry ID
+    public let status: String                            // "processing"
+    public let submittedAt: String?                      // ISO 8601 timestamp
+    public let verificationResult: VerifyIdentityResponse? // data mode only
+    public let idTypeName: String?                       // e.g. "National Identity Number (NIN)"
 }
 ```
 
-> **Final verification results are delivered via webhook.** Once the backend completes processing, SmartComply sends a webhook event to the URL configured in your Dashboard. Set up your webhook endpoint to receive the final status, extracted fields, and any failure reasons. See the [Webhooks](/webhooks) guide for the full payload reference.
+<Note>
+  **The result is a submission receipt, not a verification verdict.** `status` is `"processing"` when the user finishes: face matching, document OCR and the government database check all continue after `onComplete` fires. An entry's status moves through `pending`, `processing`, and then `passed`, `failed` or `expired`. The final status, the extracted fields and any failure reason are delivered to the webhook URL configured on your SDK Config. See [Webhooks](/webhooks#identity-verification) for the full payload.
+</Note>
 
 ---
 
@@ -193,17 +230,19 @@ public struct FlowResult {
 do {
     _ = try await sdk.createSession()
 } catch let error as SDKError {
-    print("API error \(error.statusCode):", error.message)
+    print("API error \(error.statusCode) [\(error.errorCode ?? "-")]:", error.message)
 } catch {
     print("Network error:", error.localizedDescription)
 }
 ```
 
+`SDKError` exposes `message: String`, `statusCode: Int` and `errorCode: String?`. `AuthError` and `NetworkError` both subclass it, so a single `catch let error as SDKError` covers every case.
+
 | Scenario | Cause | Resolution |
 |---|---|---|
-| `401 Unauthorized` | Invalid or missing API key | Check your key in the SmartComply Dashboard |
-| Session expired | Sessions expire after 30 minutes and are single-use | Generate a new `clientId` and call `createSession()` again |
-| Liveness timed out | The passive liveness scan has its own 12-second capture window, separate from the 30-minute session TTL. The countdown ring only runs during the active scan (once face-centering finishes) and clears as soon as the scan resolves — it does not apply retroactively once the user has finished the liveness step, and doesn't run while the user is elsewhere in the flow | The flow shows a "Time's Up" screen with a retry that reuses the same liveness entry — no need to restart the whole session |
+| `401`, `errorCode` `AUTH_ERROR` | Invalid or missing API key. Every authentication failure, including a `403`, is reported with this code and a status of `401` | Check your key in the Adhere Dashboard |
+| `404`, `errorCode` `SDK_CONFIG_NOT_FOUND` | `clientId` is not an active SDK Config | Copy the Client ID from **Settings → Integrations → SDK Setup**. Do not generate a UUID |
+| Session expired | Session tokens live 30 minutes | Present the flow again. A new session is created each time; your `clientId` never changes |
 | Camera permission denied | User denied camera access | The flow view shows a Settings deep-link automatically |
 | Upload failed after retries | Network instability | `maxUploadRetries` exhausted — the failure screen offers a retry |
 | Identity not found | ID number not found or details mismatched (data mode) | User is shown the reason and prompted to re-enter |

--- a/webhooks.mdx
+++ b/webhooks.mdx
@@ -36,19 +36,35 @@ To start receiving webhook notifications, follow these steps to configure your e
   </Step>
 </Steps>
 
+<Note>
+  There are two independent webhook channels, each with its own URL and its own signing secret:
+
+  - **Module events** (transaction monitoring, KYC) go to the URL set under **Integrations**, and are signed with the **Hash Key** you set there.
+  - **Identity verification** (`liveness.completed`, sent for every Web, Android and iOS SDK run) goes to the webhook URL set on your **SDK Config**, and is signed with that config's own webhook secret. It is generated for you, not set by you.
+
+  Both use the same `X-Adhere-Signature` header and the same HMAC-SHA256 scheme described below.
+</Note>
+
 ## Security & Verification
 
-All webhook requests from Adhere include a `X-Adhere-Signature` header. This header contains the HMAC SHA256 signature of the request body, signed with your Hash Key.
+All webhook requests from Adhere include an `X-Adhere-Signature` header in the form `sha256=<signature>`, where the signature is the **lowercase hex** HMAC-SHA256 digest of the request body.
 
 ### Verifying Signatures
 
 To ensure that a webhook request is genuinely from Adhere, you should verify the signature before processing the payload.
 
+<Warning>
+  Compute the HMAC over the **raw request body bytes**, exactly as received. Adhere signs a compact JSON serialisation with no whitespace between separators, so re-serialising a parsed payload produces different bytes and the signature will never match.
+</Warning>
+
+<Note>
+  For `liveness.completed`, the signing key is your SDK Config's webhook secret **with the dashes removed** — a 32-character hex string, not the dashed UUID form. The examples below strip them for you.
+</Note>
+
 <CodeGroup>
 ```python Python
 import hmac
 import hashlib
-import base64
 from flask import request, abort
 
 def verify_webhook(request, hash_key):
@@ -56,18 +72,16 @@ def verify_webhook(request, hash_key):
     if not sig_header:
         abort(401, "Missing signature")
 
-    # The header format is "sha256=<signature>"
+    # The header format is "sha256=<hex digest>"
     _, _, received_sig = sig_header.partition("=")
 
     # Compute the HMAC SHA256 digest of the raw request body
     raw_body = request.get_data()
-    digest = hmac.new(
-        hash_key.encode("utf-8"),
+    expected_sig = hmac.new(
+        hash_key.replace("-", "").encode("utf-8"),
         raw_body,
         hashlib.sha256
-    ).digest()
-
-    expected_sig = base64.b64encode(digest).decode("utf-8")
+    ).hexdigest()
 
     if not hmac.compare_digest(received_sig, expected_sig):
         abort(401, "Invalid signature")
@@ -76,17 +90,25 @@ def verify_webhook(request, hash_key):
 ```javascript Node.js
 const crypto = require('crypto');
 
+// `req.rawBody` must be the unparsed body. With Express:
+//   app.use(express.json({ verify: (req, res, buf) => { req.rawBody = buf; } }));
 function verifyWebhook(req, hashKey) {
-  const signature = req.headers['x-hub-signature'];
+  const signature = req.headers['x-adhere-signature'];
   if (!signature) {
     throw new Error('Missing signature');
   }
 
-  const [algo, receivedSig] = signature.split('=');
-  const hmac = crypto.createHmac('sha256', hashKey);
-  const digest = hmac.update(req.rawBody).digest('base64');
+  const receivedSig = signature.replace(/^sha256=/, '');
+  const expected = crypto
+    .createHmac('sha256', hashKey.replace(/-/g, ''))
+    .update(req.rawBody)
+    .digest('hex');
 
-  if (receivedSig !== digest) {
+  const valid =
+    receivedSig.length === expected.length &&
+    crypto.timingSafeEqual(Buffer.from(receivedSig, 'hex'), Buffer.from(expected, 'hex'));
+
+  if (!valid) {
     throw new Error('Invalid signature');
   }
 }
@@ -94,9 +116,10 @@ function verifyWebhook(req, hashKey) {
 
 ```php PHP
 function verify_webhook($request_body, $hash_key, $received_sig) {
-    $expected_sig = base64_encode(hash_hmac('sha256', $request_body, $hash_key, true));
+    $received_sig = preg_replace('/^sha256=/', '', $received_sig);
+    $expected_sig = hash_hmac('sha256', $request_body, str_replace('-', '', $hash_key));
 
-    if (!hash_equals($received_sig, $expected_sig)) {
+    if (!hash_equals($expected_sig, $received_sig)) {
         http_response_code(401);
         exit("Invalid signature");
     }
@@ -107,8 +130,8 @@ function verify_webhook($request_body, $hash_key, $received_sig) {
 import (
 	"crypto/hmac"
 	"crypto/sha256"
-	"encoding/base64"
-	"io/ioutil"
+	"encoding/hex"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -119,17 +142,17 @@ func verifyWebhook(w http.ResponseWriter, r *http.Request, hashKey string) bool 
 		return false
 	}
 
-	// Header format is "sha256=<signature>"
-	parts := strings.Split(sigHeader, "=")
+	// Header format is "sha256=<hex digest>"
+	parts := strings.SplitN(sigHeader, "=", 2)
 	if len(parts) != 2 {
 		return false
 	}
 	receivedSig := parts[1]
 
-	body, _ := ioutil.ReadAll(r.Body)
-	h := hmac.New(sha256.New, []byte(hashKey))
+	body, _ := io.ReadAll(r.Body)
+	h := hmac.New(sha256.New, []byte(strings.ReplaceAll(hashKey, "-", "")))
 	h.Write(body)
-	expectedSig := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	expectedSig := hex.EncodeToString(h.Sum(nil))
 
 	return hmac.Equal([]byte(receivedSig), []byte(expectedSig))
 }
@@ -141,15 +164,19 @@ using System.Text;
 
 public bool VerifyWebhook(string requestBody, string hashKey, string receivedSig)
 {
-    var keyBytes = Encoding.UTF8.GetBytes(hashKey);
+    receivedSig = receivedSig.StartsWith("sha256=") ? receivedSig.Substring(7) : receivedSig;
+
+    var keyBytes = Encoding.UTF8.GetBytes(hashKey.Replace("-", ""));
     var bodyBytes = Encoding.UTF8.GetBytes(requestBody);
 
     using (var hmac = new HMACSHA256(keyBytes))
     {
         var hashBytes = hmac.ComputeHash(bodyBytes);
-        var expectedSig = Convert.ToBase64String(hashBytes);
+        var expectedSig = Convert.ToHexString(hashBytes).ToLowerInvariant();
 
-        return expectedSig == receivedSig;
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(expectedSig),
+            Encoding.UTF8.GetBytes(receivedSig));
     }
 }
 ```
@@ -161,7 +188,7 @@ public bool VerifyWebhook(string requestBody, string hashKey, string receivedSig
 
 ## Event Payload Structure
 
-All webhooks follow a consistent JSON structure:
+Module events follow a consistent JSON structure:
 
 | Parameter | Type | Description |
 | :--- | :--- | :--- |
@@ -169,6 +196,8 @@ All webhooks follow a consistent JSON structure:
 | `module` | string | The Adhere module that triggered the event (e.g., `transaction_monitoring`, `kyc`). |
 | `event` | string | The specific event type. |
 | `data` | object | The actual payload data (e.g., transaction details, KYC results). |
+
+[Identity verification](#identity-verification) does not use this envelope. Its payload is flat, with the verification fields at the top level.
 
 ## Supported Events
 
@@ -226,6 +255,122 @@ All webhooks follow a consistent JSON structure:
         }
         ```
 
+### Identity Verification
+
+*   **Sent by**: every Web, Android and iOS SDK verification
+*   **Delivered to**: the webhook URL on your **SDK Config** (not the Integrations URL)
+*   **Events**:
+    *   `liveness.completed`: fired once per verification, after face matching and, for document runs, OCR have finished.
+
+This payload is **flat** — there is no `success` / `module` / `data` wrapper.
+
+```json
+POST https://your-server.com/webhook
+Content-Type: application/json
+X-Adhere-Signature: sha256=<hmac-sha256-hex>
+
+{
+  "event": "liveness.completed",
+  "verification_id": 42,
+  "verification_type": "data_verification",
+  "status": "passed",
+  "failure_reason": null,
+  "timestamp": "2026-08-08T10:15:00.000Z",
+  "subject": {
+    "identifier": "12345678901",
+    "identifier_type": "National Identity Number (NIN)",
+    "country": "nigeria"
+  },
+  "biometrics": {
+    "liveness_verified": true,
+    "face_match": {
+      "attempted": true,
+      "verified": true,
+      "confidence_percentage": 70.0,
+      "threshold_percentage": 35.0
+    },
+    "selfie_url": "https://.../autoshot.jpg",
+    "face_analysis": {
+      "gender": "Female",
+      "dominant_emotion": "neutral",
+      "face_quality": {
+        "face_detected": true,
+        "face_confidence": 0.98,
+        "blur_score": 142.3,
+        "is_blurry": false
+      }
+    }
+  },
+  "activity": {
+    "session_id": "da7623bd-9158-4b56-a9e4-4bccf3c0133f",
+    "started_at": "2026-08-08T10:12:00.000Z",
+    "submitted_at": "2026-08-08T10:14:30.000Z",
+    "completed_at": "2026-08-08T10:15:00.000Z",
+    "duration_seconds": 180
+  },
+  "request_context": {
+    "ip": { "address": "102.67.1.66", "city": "Lagos", "country_code": "NG" },
+    "device": { "user_agent": "Mozilla/5.0 ...", "type": "desktop", "os": "Windows" }
+  },
+  "customer_profile": {
+    "first_name": "AMARA",
+    "last_name": "OKAFOR",
+    "other_name": null,
+    "date_of_birth": "01-Jan-1997",
+    "age": 29,
+    "gender": "Female",
+    "id_number": "12345678901",
+    "serial_number": null,
+    "occupation": null,
+    "place_of_birth": null,
+    "place_of_live": "...",
+    "date_of_issue": null,
+    "photo_url": null
+  }
+}
+```
+
+`verification_type` is `data_verification`, `document_verification` or `liveness_only`. For a **document** run the same top-level shape applies, with a `document` block (OCR fields plus a document-to-selfie face match) in place of `customer_profile`:
+
+```json
+"document": {
+  "status": "verified",
+  "document_type": "passport",
+  "is_expired": false,
+  "first_name": "AMARA",
+  "last_name": "OKAFOR",
+  "date_of_birth": "1997-01-01",
+  "age": 29,
+  "gender": "Female",
+  "nationality": "NGA",
+  "document_number": "A12345678",
+  "expiry_date": "2030-06-15",
+  "issue_date": "2020-06-15",
+  "issuing_authority": "...",
+  "document_url": "https://.../document.jpg",
+  "document_back_url": null,
+  "face_match": {
+    "attempted": true,
+    "verified": true,
+    "confidence_percentage": 55.0,
+    "threshold_percentage": 35.0,
+    "reason": null,
+    "selfie_url": "https://.../autoshot.jpg",
+    "document_face_url": "https://.../document_face.jpg"
+  }
+}
+```
+
+<Note>
+  `document` also carries `place_of_birth`, `place_of_issue`, `address`, `district`, `division`, `location`, `sub_location`, `serial_number`, and `barcode_number` — `null` unless the specific document type carries that field. `face_match.reason` is populated with a user-facing explanation when `verified` is `false` or the match was skipped.
+</Note>
+
+<Warning>
+  `status: "passed"` means **the check ran to completion — not that the person matched**. A face mismatch, a low confidence score, or an expired document still reports `status: "passed"`, with the real outcome recorded in `biometrics.face_match.verified` (and `document.is_expired` for document verification). `status: "failed"` is reserved for cases where the check itself could not run: a service error, no selfie captured, or a government database rejection. Never gate access on `status` alone — always check `face_match.verified`.
+</Warning>
+
+`verification_id` matches the `entryId` returned by the SDK's completion callback.
+
 ## Testing Locally
 
 Before deploying to production, we recommend testing your webhook implementation locally.
@@ -237,8 +382,8 @@ Before deploying to production, we recommend testing your webhook implementation
 ## Best Practices
 
 *   **Acknowledge Immediately**: Your server should return a `200 OK` response as quickly as possible. Heavy processing should be handled asynchronously using a task queue.
-*   **Handle Retries**: Adhere will retry failed webhook deliveries (non-2xx responses) up to 3 times with an exponential backoff.
-*   **Use Idempotency**: Ensure your system can handle the same webhook multiple times safely. Use the event's unique ID to track processed events.
+*   **Handle Retries**: Adhere will retry failed webhook deliveries (non-2xx responses) up to 3 times, with an exponential backoff that caps at 10 minutes.
+*   **Use Idempotency**: Ensure your system can handle the same webhook multiple times safely. There is no separate delivery ID — de-duplicate on the resource identifier in the payload (`verification_id` for `liveness.completed`, `data.id` for module events).
 
 <Note>
   If your server does not return a 2xx response, Adhere will consider the delivery as failed and will attempt to retry.


### PR DESCRIPTION
The mobile SDK pages had errors that stop a new integrator from getting a single successful call. I checked every claim on those pages against the SDK and backend source before changing anything.

Two blockers:

- `clientId` was documented as a UUID the caller generates per attempt. It is actually the SDK Config UUID issued in the dashboard, so the documented code returned `404 SDK_CONFIG_NOT_FOUND` on the very first call.
- iOS `SDKConfig` defaults to `.sandbox`, which is `http://localhost:8000`, and the Quick Start left the parameter out. A copied integration pointed at the phone itself.

Other fixes on both pages: API keys are 64 characters with no `pk_live_` prefix, the callback status is `"processing"` and is a submission receipt rather than a verdict, and `verifiedName` plus Android's `TYPE_FAILURE` branch are removed because neither is ever populated or emitted. Also corrected Kotlin and Java versions, the ProGuard section, the camera permission note for the embedded Compose path, session lifetime, and the back-side capture rule.

`webhooks.mdx`: all five signature samples computed base64 while the backend sends lowercase hex, so every one of them rejected real deliveries. The Node sample also read the wrong header name. Added the `liveness.completed` event that both SDK pages link to but which was not on the page.

`error_codes.mdx`: added the SDK error codes and the missing 402, 409 and 429 rows.

Checked with `mint dev` and `mint broken-links`. All four pages render with no new warnings.

The iOS install section is untouched, and `flutter_sdk.mdx` is left alone since it is not in the navigation.

One thing worth settling separately: the Web SDK page says sandbox is temporarily unavailable, while these pages now say sandbox is a localhost pointer and was never a hosted environment. Both match their own code, but the site should tell one story.
