### PR TITLE
docs: fix SDK identifier scope, session TTL contradiction, add liveness timing

### DIFF
--- a/libraries/android_sdk.mdx
+++ b/libraries/android_sdk.mdx
@@ -259,6 +259,7 @@ data class SDKConfig(
 |---|---|---|
 | `TYPE_FAILURE` with `"401"` | Invalid or missing API key | Check your key in the SmartComply Dashboard |
 | `TYPE_FAILURE` — session expired | Session tokens have a 30-minute TTL | Generate a new `clientId` on the next launch |
+| `TYPE_FAILURE` — liveness timed out | The passive liveness scan has its own 12-second capture window, separate from the 30-minute session TTL. This timer only runs during the active scan (once the camera has centered and locked onto the face) and is cleared as soon as the scan resolves — it never applies retroactively to a step the user has already finished, and doesn't run while the user is elsewhere in the flow. | The built-in "Time's Up" screen offers a retry against the same liveness entry — no need to restart the whole flow |
 | `TYPE_CANCELLED` | User pressed back | Re-launch when the user is ready to retry |
 | Upload failed | Network instability | The built-in failure screen offers a retry; if retries are exhausted `TYPE_FAILURE` is returned |
 

--- a/libraries/ios_sdk.mdx
+++ b/libraries/ios_sdk.mdx
@@ -202,7 +202,8 @@ do {
 | Scenario | Cause | Resolution |
 |---|---|---|
 | `401 Unauthorized` | Invalid or missing API key | Check your key in the SmartComply Dashboard |
-| Session expired | Sessions expire after 2 hours and are single-use | Generate a new `clientId` and call `createSession()` again |
+| Session expired | Sessions expire after 30 minutes and are single-use | Generate a new `clientId` and call `createSession()` again |
+| Liveness timed out | The passive liveness scan has its own 12-second capture window, separate from the 30-minute session TTL. The countdown ring only runs during the active scan (once face-centering finishes) and clears as soon as the scan resolves — it does not apply retroactively once the user has finished the liveness step, and doesn't run while the user is elsewhere in the flow | The flow shows a "Time's Up" screen with a retry that reuses the same liveness entry — no need to restart the whole session |
 | Camera permission denied | User denied camera access | The flow view shows a Settings deep-link automatically |
 | Upload failed after retries | Network instability | `maxUploadRetries` exhausted — the failure screen offers a retry |
 | Identity not found | ID number not found or details mismatched (data mode) | User is shown the reason and prompted to re-enter |

--- a/libraries/smartcomply_sdk.mdx
+++ b/libraries/smartcomply_sdk.mdx
@@ -15,7 +15,7 @@ The SDK mounts a drop-in widget over your application, handling document capture
 - **CDN & npm Support** — Install via npm/yarn or load directly from a CDN with zero build steps.
 - **Dynamic Routing** — Automatically adapts document and verification requirements from your dashboard configuration.
 - **Single-Use Sessions** — `clientId` is your permanent integration key (from your SDK Config) and is reused for every session. Each `createSession()` call issues a fresh, single-use session token — that token, not the `clientId`, is what's scoped to one verification.
-- **Nigeria & Global Identity** — Supports BVN, NIN, passports, driver's licenses, voter's cards, and other document/data channels enabled in your dashboard.
+- **Multi-Country Identity** — Supports data and document channels across Nigeria (BVN, NIN, passports, driver's licenses, voter's cards, and more), Ghana, Kenya, South Africa, and Cote d'Ivoire, with generic passport verification available for other countries and country-agnostic liveness/face-match checks — exact channels depend on what's enabled in your dashboard.
 - **Two-Sided Document Capture** — Front is always required; back is required, optional, or not offered depending on the document type (e.g. NIN is optional-back, since not every physical NIN document has a usable reverse side).
 - **Hardware Agnostic Liveness** — Uses native webcam and MediaRecorder API for cross-platform compatibility. A single passive scan (blink + natural head movement) — no discrete step-by-step prompts.
 
@@ -44,7 +44,7 @@ const { SmartComplyFlow, SmartComply } = window.SmartComplySDK;
 Other CDN options:
 
 ```html
-<!-- Always the newest release, including any future major version — for
+<!-- Always use the newest release, including any future major version — for
      prototyping, or if you specifically want every change instantly -->
 <script src="https://cdn.jsdelivr.net/npm/smartcomply-web-sdk@latest/dist/smartcomply.browser.js"></script>
 
@@ -261,6 +261,12 @@ const run = async () => {
 
 run();
 ```
+
+<Note>
+  The liveness scan itself has its own **12-second capture window**, separate from the 30-minute session TTL above. This timer starts only when active recording begins — right after the camera has centered on the user's face and briefly re-stabilized (autofocus/exposure) — not from when the camera first opens. From that point, the widget shows a countdown ring around the face oval; the scan must detect the passive liveness signal (blink + natural head movement) within those 12 seconds or it fails with a "Time's Up" screen and a **Try Again** button that restarts the scan using the same liveness entry (no re-charge).
+
+  This timer is entirely local to the browser tab and only runs *during* the active scan — it is cleared the moment the scan resolves (success or timeout) and does not persist, run in the background, or resume if the user leaves and returns. In practice this means: **if the user has already completed the liveness/face step and moved on to another part of the flow (e.g. reviewing their submission), the 12-second window is long finished and irrelevant** — nothing about that step can time out again. The only clock still running at that point is the 30-minute session TTL, which governs the SDK's API calls generally, not the completed scan.
+</Note>
 
 ---
 


### PR DESCRIPTION
- Web SDK: correct "Nigeria & Global Identity" claim to list actual supported countries (Nigeria, Ghana, Kenya, South Africa, Cote d'Ivoire) plus generic passport fallback and country-agnostic biometrics, instead of an inaccurate Nigeria-only framing
- iOS SDK: fix session expiry contradiction (docs said 2 hours, actual backend TTL is 30 minutes, matching Web/Android docs)
- Web/Android/iOS SDK: document the separate 12-second liveness scan window (distinct from the 30-minute session TTL), including when it starts, what happens on timeout, and that it cannot expire retroactively once the liveness step is complete
- Web SDK: fix "Always the newest release" comment grammar to "Always use the newest release"