### PR TITLE
docs: backport loan fraud check global identifiers to v1/v2, fix Ghan…a ID card OpenAPI spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -931,17 +931,11 @@ paths:
           application/json:
             schema:
               type: object
-              required: [identification_number, id_type]
+              required: [identification_number]
               properties:
                 identification_number:
                   type: string
-                  description:
-                    Ghana Card, Passport, Voter ID, SSNIT, or Driver's License
-                    number
-                id_type:
-                  type: string
-                  description:
-                    "GhanaCard, Passport, VoterID, SSNIT, or DriversLicense"
+                  description: The customer's Ghana Card number
       responses:
         "200": { description: ID card verified }
         "400": { $ref: "#/components/responses/BadRequest" }

--- a/v1/loan/individual_fraud_check.mdx
+++ b/v1/loan/individual_fraud_check.mdx
@@ -39,6 +39,14 @@ Our Loan Fraud Check API allows you to assess the fraud risk of a loan applicati
 }
 ```
 
+For non-Nigeria applicants, omit `bvn` and pass `identifier` (the ID value) and `identifier_type` (the key, e.g. `national_id`, `ghana_card`) instead. This enables multi-country loan fraud assessment.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `bvn` | string | Nigeria only | 11-digit Bank Verification Number. Use `identifier` + `identifier_type` for other countries |
+| `identifier` | string | Non-Nigeria only | Customer identifier for non-Nigeria applicants (e.g. a Kenya national ID number) |
+| `identifier_type` | string | Non-Nigeria only | Key of the identifier type (e.g. `bvn`, `national_id`, `ghana_card`). Required when `identifier` is provided |
+
 200 OK Response
 
 ```json

--- a/v2/loan/individual_fraud_check.mdx
+++ b/v2/loan/individual_fraud_check.mdx
@@ -39,6 +39,14 @@ Our Loan Fraud Check API allows you to assess the fraud risk of a loan applicati
 }
 ```
 
+For non-Nigeria applicants, omit `bvn` and pass `identifier` (the ID value) and `identifier_type` (the key, e.g. `national_id`, `ghana_card`) instead. This enables multi-country loan fraud assessment.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `bvn` | string | Nigeria only | 11-digit Bank Verification Number. Use `identifier` + `identifier_type` for other countries |
+| `identifier` | string | Non-Nigeria only | Customer identifier for non-Nigeria applicants (e.g. a Kenya national ID number) |
+| `identifier_type` | string | Non-Nigeria only | Key of the identifier type (e.g. `bvn`, `national_id`, `ghana_card`). Required when `identifier` is provided |
+
 200 OK Response
 
 ```json


### PR DESCRIPTION
- v1/v2 loan fraud check: add identifier/identifier_type fields and the multi-country note that v3 already had, so non-Nigeria applicants are documented consistently across all versions
- openapi.yaml: drop id_type from the Ghana ID Card request schema — verified against onboarding/views.py and the Smile/Youverify provider configs in adhere-backend that id_type is never a client-supplied field (it's a hardcoded server-side constant), so requiring it in the API playground was wrong and would cause a request built from the docs to look like it needs a field the backend never reads from the client